### PR TITLE
Cut work from keyed list patches and vnode create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## Unreleased
+
+Throughput work in the 3.2 runtime. Public API and observable semantics are unchanged aside from one mixed-key correction noted below.
+
+### Keyed patch
+
+- Same-order keyed children patch in place. No `Map`/`Set`, no `insertBefore`, no per-child node arrays.
+- `collectDom` is gone. Moves use `_dom`…`_end` as a contiguous range, so a fragment (or a component whose root is a fragment) stays together when it is reordered.
+- A new keyed node no longer steals an unkeyed sibling of the same type. That was a correctness hole; mixed keys already warn in development.
+
+### Vnode create
+
+- `jsx` / `jsxs` / `jsxDEV` build a vnode directly. They no longer copy props and then call `h`, which copied them again.
+- `h` copies props only when rest children have to be written back onto the object (the `html` / hyperscript path).
+- Empty child lists and text nodes share one empty array. `flatten` no longer wraps every item in `normalizeChild` after it has already dropped `null` / `true` / `false`.
+- An array returned from `render()` becomes a fragment without spreading into `h`.
+
+### DOM writes
+
+- Style object keys that did not change skip `setProperty`.
+- A DOM property is not assigned when it already matches. Controlled inputs keep the caret when `value` is unchanged.
+- `setAttribute` is still used for string values, including SVG `points`. Skipping it after a property write broke polyline updates: `el.points` is an `SVGPointList`, not a string.
+
+### SSR
+
+- `escapeHtml` runs one `/[&<>"]/` pass instead of four replacements.
+- `stringify` concatenates in a loop instead of `map` / `join`.
+
+### Mission Control
+
+- Fleet filter is one pass over the 100 units, then an in-place sort.
+- Callsign clicks are delegated on `tbody`. The previous per-row `onClick` closed over `unit.id` every tick and rebound 100 listeners.
+
+### Size
+
+IIFE gzip 5212 bytes (budget 5632). ESM gzip 5759 bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Throughput work in the 3.2 runtime. Public API and observable semantics are unch
 ### Keyed patch
 
 - Same-order keyed children patch in place. No `Map`/`Set`, no `insertBefore`, no per-child node arrays.
-- `collectDom` is gone. Moves use `_dom`…`_end` as a contiguous range, so a fragment (or a component whose root is a fragment) stays together when it is reordered.
+- `collectDom` is gone. Moves walk the live instance tree (`_dom`…`_end`, through nested components) as a contiguous range, so a fragment stays together when it is reordered even if an inner component independently changed its root.
 - A new keyed node no longer steals an unkeyed sibling of the same type. That was a correctness hole; mixed keys already warn in development.
 
 ### Vnode create
@@ -35,4 +35,4 @@ Throughput work in the 3.2 runtime. Public API and observable semantics are unch
 
 ### Size
 
-IIFE gzip 5212 bytes (budget 5632). ESM gzip 5759 bytes.
+IIFE gzip 5279 bytes (budget 5632). ESM gzip 5844 bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ Throughput work in the 3.2 runtime. Public API and observable semantics are unch
 
 ### Vnode create
 
-- `jsx` / `jsxs` / `jsxDEV` build a vnode directly. They no longer copy props and then call `h`, which copied them again.
-- `h` copies props only when rest children have to be written back onto the object (the `html` / hyperscript path).
-- Empty child lists and text nodes share one empty array. `flatten` no longer wraps every item in `normalizeChild` after it has already dropped `null` / `true` / `false`.
+- `jsx` / `jsxs` / `jsxDEV` build a vnode directly. They snapshot props once instead of copying them and then calling `h`, which copied them again.
+- `h` keeps its one props snapshot for public hyperscript semantics.
+- `flatten` no longer wraps every item in `normalizeChild` after it has already dropped `null` / `true` / `false`.
 - An array returned from `render()` becomes a fragment without spreading into `h`.
 
 ### DOM writes
@@ -35,4 +35,4 @@ Throughput work in the 3.2 runtime. Public API and observable semantics are unch
 
 ### Size
 
-IIFE gzip 5279 bytes (budget 5632). ESM gzip 5844 bytes.
+IIFE gzip 5267 bytes (budget 5632). ESM gzip 5826 bytes.

--- a/apps/www/docs/lists.md
+++ b/apps/www/docs/lists.md
@@ -19,4 +19,8 @@ render() {
 }
 ```
 
+Keys are the identity of a row. Same key and type keeps the DOM node and any child component state. When every child has a key and the keys stay in the same order, the patcher updates text and attributes in place and does not call `insertBefore`.
+
+A new keyed node does not reuse an unkeyed sibling of the same type. Mix keys on a dynamic list only if you mean it — development warns when some children have keys and others do not.
+
 Duplicate or missing keys on a dynamic list warn in development.

--- a/apps/www/docs/lists.md
+++ b/apps/www/docs/lists.md
@@ -23,4 +23,4 @@ Keys are the identity of a row. Same key and type keeps the DOM node and any chi
 
 A new keyed node does not reuse an unkeyed sibling of the same type. Mix keys on a dynamic list only if you mean it — development warns when some children have keys and others do not.
 
-Duplicate or missing keys on a dynamic list warn in development.
+Mixed or duplicate keys on a dynamic list warn in development.

--- a/apps/www/docs/rendering.md
+++ b/apps/www/docs/rendering.md
@@ -25,9 +25,11 @@ Updates:
 2. The instance is marked dirty and queued
 3. A microtask flushes the queue
 4. `render()` produces a new vnode — children with the same props are skipped
-5. A keyed diff patches the previous tree
+5. A keyed diff patches the previous tree. Same-order keyed children patch in place; fragments move as the contiguous range between their marker comments
 
 `this.observe(store)` marks the instance dirty when the store changes, without a dummy `setState`.
+
+DOM writes follow the tree, not the other way around. Unchanged style keys are not rewritten. A controlled `value` that already matches the input is left alone so the caret stays put. SVG attributes such as `points` still go through `setAttribute` — the animated `SVGPointList` property is not a string.
 
 The 2.x renderer assigned `node.innerHTML = ""` on every update. That is gone on purpose.
 

--- a/apps/www/src/demos/mission-control/mission-control.js
+++ b/apps/www/src/demos/mission-control/mission-control.js
@@ -515,6 +515,12 @@ export function createMissionControl({ create, createStore, html }) {
         : "ascending";
       this.update({ sort: key, direction });
     },
+    selectRow(event) {
+      const button = event.target.closest(".mission-callsign");
+      if (!button || !event.currentTarget.contains(button)) return;
+      const id = button.closest("[data-unit-id]")?.getAttribute("data-unit-id");
+      if (id) this.props.onSelect(id, button);
+    },
     onMount() {
       this.observe(this.props.store);
       this._focus = () => this._filter?.focus();
@@ -527,15 +533,21 @@ export function createMissionControl({ create, createStore, html }) {
     render() {
       const state = this.props.store.get();
       const needle = this.state.query.trim().toLowerCase();
-      const visible = state.units
-        .filter((unit) => this.state.status === "all" || unit.status === this.state.status)
-        .filter((unit) => !needle || unit.id.toLowerCase().includes(needle) || unit.sector.toLowerCase().includes(needle));
+      const status = this.state.status;
+      const visible = [];
+      for (const unit of state.units) {
+        if (status !== "all" && unit.status !== status) continue;
+        if (needle && !unit.id.toLowerCase().includes(needle) && !unit.sector.toLowerCase().includes(needle)) continue;
+        visible.push(unit);
+      }
       const direction = this.state.direction === "ascending" ? 1 : -1;
-      const sorted = [...visible].sort((left, right) => {
-        const a = this.state.sort === "status" ? STATUS_ORDER[left.status] : left[this.state.sort];
-        const b = this.state.sort === "status" ? STATUS_ORDER[right.status] : right[this.state.sort];
+      const sortKey = this.state.sort;
+      visible.sort((left, right) => {
+        const a = sortKey === "status" ? STATUS_ORDER[left.status] : left[sortKey];
+        const b = sortKey === "status" ? STATUS_ORDER[right.status] : right[sortKey];
         return (typeof a === "string" ? a.localeCompare(b) : a - b) * direction;
       });
+      const sorted = visible;
       const ariaSort = (key) => this.state.sort === key ? this.state.direction : "none";
       return html`
         <section class="mission-panel mission-fleet">
@@ -584,7 +596,7 @@ export function createMissionControl({ create, createStore, html }) {
                   <th scope="col" aria-sort=${ariaSort("latency")}><button type="button" onClick=${() => this.sortBy("latency")}>Latency</button></th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody onClick=${this.selectRow}>
                 ${sorted.map((unit) => html`
                   <tr key=${unit.id} data-unit-id=${unit.id} data-reading=${unit.signal}>
                     <td>
@@ -592,7 +604,6 @@ export function createMissionControl({ create, createStore, html }) {
                         type="button"
                         class="mission-callsign"
                         aria-label=${`Inspect ${unit.id}`}
-                        onClick=${(event) => this.props.onSelect(unit.id, event.currentTarget)}
                       >
                         ${unit.id}<small>${unit.sector}</small>
                       </button>

--- a/apps/www/src/pages/heritage.tsx
+++ b/apps/www/src/pages/heritage.tsx
@@ -19,7 +19,7 @@ export const HeritagePage = create({
           <dt>2.x update</dt>
           <dd>Wipe the DOM, run render(), insert a new tree</dd>
           <dt>3.x update</dt>
-          <dd>DEV clone + freeze, observe(store), keyed vnode patch, skip unchanged children</dd>
+          <dd>DEV clone + freeze, observe(store), keyed vnode patch in place when order is stable, skip unchanged children</dd>
           <dt>Lifecycle</dt>
           <dd>
             <code>_didMount</code> / <code>_didUpdate</code> / <code>_beforeMount</code> still work. Prefer{" "}

--- a/packages/svenjs/src/dom.ts
+++ b/packages/svenjs/src/dom.ts
@@ -1,7 +1,7 @@
 import type { Props } from "./types";
 
 export const SVG_NS = "http://www.w3.org/2000/svg";
-const SKIP = new Set(["key", "children", "ref"]);
+const SKIP = new Set(["key", "children", "ref", "class", "className"]);
 const INVALID_ATTRIBUTE = /[\s"'<>/=`]/;
 
 const LISTENER = "_svenL";
@@ -75,20 +75,21 @@ function applyStyle(el: Element, oldVal: unknown, newVal: unknown) {
     return;
   }
   if (typeof oldVal === "string") el.removeAttribute("style");
-  if (typeof oldVal === "object" && oldVal) {
-    for (const k of Object.keys(oldVal as object)) {
+  const prev = typeof oldVal === "object" && oldVal ? (oldVal as Record<string, unknown>) : null;
+  if (prev) {
+    for (const k in prev) {
       if (!(k in (newVal as Record<string, unknown>))) style.removeProperty(styleName(k));
     }
   }
-  for (const k of Object.keys(newVal as object)) {
+  for (const k in newVal as object) {
     const value = (newVal as Record<string, unknown>)[k];
     if (value == null || value === false || value === "") style.removeProperty(styleName(k));
-    else style.setProperty(styleName(k), String(value));
+    else if (!Object.is(prev?.[k], value)) style.setProperty(styleName(k), String(value));
   }
 }
 
-export function setProp(el: Element, name: string, oldVal: unknown, newVal: unknown, props?: Props) {
-  if (!validAttributeName(name) || SKIP.has(name) || name === "class" || name === "className") return;
+export function setProp(el: Element, name: string, oldVal: unknown, newVal: unknown) {
+  if (!validAttributeName(name) || SKIP.has(name)) return;
 
   const ev = eventName(name);
   if (ev) {
@@ -129,7 +130,8 @@ export function setProp(el: Element, name: string, oldVal: unknown, newVal: unkn
 
   if (name in el && name !== "list" && name !== "type" && name !== "size") {
     try {
-      (el as any)[name] = newVal ?? "";
+      const next = newVal ?? "";
+      if ((el as any)[name] !== next) (el as any)[name] = next;
     } catch {
       /* readonly */
     }
@@ -153,10 +155,10 @@ export function patchProps(el: Element, oldP: Props, newP: Props) {
   if (oldClass !== newClass) applyClass(el, newClass);
 
   for (const k in old) {
-    if (!(k in next)) setProp(el, k, old[k], undefined, next);
+    if (!(k in next)) setProp(el, k, old[k], undefined);
   }
   for (const k in next) {
-    if (old[k] !== next[k]) setProp(el, k, old[k], next[k], next);
+    if (old[k] !== next[k]) setProp(el, k, old[k], next[k]);
   }
 }
 

--- a/packages/svenjs/src/h.ts
+++ b/packages/svenjs/src/h.ts
@@ -1,7 +1,5 @@
 import { FRAGMENT, TEXT, type Key, type Props, type VNode } from "./types";
 
-const EMPTY_CHILDREN: VNode[] = [];
-
 export function vnode(
   type: VNode["type"],
   props: Props | null | undefined,
@@ -12,7 +10,7 @@ export function vnode(
 }
 
 export function textVNode(value: string): VNode {
-  return vnode(TEXT, { nodeValue: value }, EMPTY_CHILDREN, undefined);
+  return vnode(TEXT, { nodeValue: value }, [], undefined);
 }
 
 export function normalizeChild(child: unknown): VNode | null {
@@ -30,23 +28,23 @@ export function flatten(list: unknown[], out: VNode[] = []): VNode[] {
     else if (typeof item === "object" && "type" in (item as VNode)) out.push(item as VNode);
     else out.push(textVNode(String(item)));
   }
-  return out.length ? out : EMPTY_CHILDREN;
+  return out;
 }
 
 export function childVNodes(fromProps: unknown): VNode[] {
-  if (fromProps === undefined) return EMPTY_CHILDREN;
-  if (Array.isArray(fromProps)) return fromProps.length ? flatten(fromProps) : EMPTY_CHILDREN;
+  if (fromProps === undefined) return [];
+  if (Array.isArray(fromProps)) return flatten(fromProps);
   const n = normalizeChild(fromProps);
-  return n ? [n] : EMPTY_CHILDREN;
+  return n ? [n] : [];
 }
 
 export function h(type: VNode["type"], props: Props | null | undefined, ...kids: unknown[]): VNode {
-  const key = props?.key as Key | undefined;
+  const p = props ? { ...props } : {};
+  const key = p.key as Key | undefined;
   if (kids.length) {
-    const p = props ? { ...props, children: kids.length === 1 ? kids[0] : kids } : { children: kids.length === 1 ? kids[0] : kids };
-    return vnode(type, p, flatten(kids), key);
+    p.children = kids.length === 1 ? kids[0] : kids;
   }
-  return vnode(type, props ?? {}, childVNodes(props?.children), key);
+  return vnode(type, p, kids.length ? flatten(kids) : childVNodes(p.children), key);
 }
 
 export function normalizeRender(output: unknown): VNode | null {

--- a/packages/svenjs/src/h.ts
+++ b/packages/svenjs/src/h.ts
@@ -1,5 +1,7 @@
 import { FRAGMENT, TEXT, type Key, type Props, type VNode } from "./types";
 
+const EMPTY_CHILDREN: VNode[] = [];
+
 export function vnode(
   type: VNode["type"],
   props: Props | null | undefined,
@@ -10,12 +12,12 @@ export function vnode(
 }
 
 export function textVNode(value: string): VNode {
-  return vnode(TEXT, { nodeValue: value }, [], undefined);
+  return vnode(TEXT, { nodeValue: value }, EMPTY_CHILDREN, undefined);
 }
 
 export function normalizeChild(child: unknown): VNode | null {
   if (child == null || child === false || child === true) return null;
-  if (typeof child === "object" && child !== null && "type" in (child as VNode)) {
+  if (typeof child === "object" && "type" in (child as VNode)) {
     return child as VNode;
   }
   return textVNode(String(child));
@@ -25,24 +27,29 @@ export function flatten(list: unknown[], out: VNode[] = []): VNode[] {
   for (const item of list) {
     if (item == null || item === false || item === true) continue;
     if (Array.isArray(item)) flatten(item, out);
-    else {
-      const n = normalizeChild(item);
-      if (n) out.push(n);
-    }
+    else if (typeof item === "object" && "type" in (item as VNode)) out.push(item as VNode);
+    else out.push(textVNode(String(item)));
   }
-  return out;
+  return out.length ? out : EMPTY_CHILDREN;
+}
+
+export function childVNodes(fromProps: unknown): VNode[] {
+  if (fromProps === undefined) return EMPTY_CHILDREN;
+  if (Array.isArray(fromProps)) return fromProps.length ? flatten(fromProps) : EMPTY_CHILDREN;
+  const n = normalizeChild(fromProps);
+  return n ? [n] : EMPTY_CHILDREN;
 }
 
 export function h(type: VNode["type"], props: Props | null | undefined, ...kids: unknown[]): VNode {
-  const p = props ? { ...props } : {};
-  const key = p.key as Key | undefined;
-  const fromProps = p.children;
-  const raw = kids.length ? kids : fromProps !== undefined ? [].concat(fromProps as never) : [];
-  if (kids.length) p.children = kids.length === 1 ? kids[0] : kids;
-  return vnode(type, p, flatten(raw), key);
+  const key = props?.key as Key | undefined;
+  if (kids.length) {
+    const p = props ? { ...props, children: kids.length === 1 ? kids[0] : kids } : { children: kids.length === 1 ? kids[0] : kids };
+    return vnode(type, p, flatten(kids), key);
+  }
+  return vnode(type, props ?? {}, childVNodes(props?.children), key);
 }
 
 export function normalizeRender(output: unknown): VNode | null {
-  if (Array.isArray(output)) return h(FRAGMENT, {}, ...output);
+  if (Array.isArray(output)) return vnode(FRAGMENT, {}, flatten(output), undefined);
   return normalizeChild(output);
 }

--- a/packages/svenjs/src/jsx-runtime.ts
+++ b/packages/svenjs/src/jsx-runtime.ts
@@ -5,7 +5,8 @@ export { FRAGMENT as Fragment };
 export type { JSX } from "./types";
 
 export function jsx(type: VNode["type"], props: Record<string, unknown> | null, key?: string | number): VNode {
-  const p = props ?? {};
+  const p = props ? { ...props } : {};
+  if (key !== undefined) p.key = key;
   return vnode(type, p, childVNodes(p.children), key !== undefined ? key : (p.key as Key | undefined));
 }
 

--- a/packages/svenjs/src/jsx-runtime.ts
+++ b/packages/svenjs/src/jsx-runtime.ts
@@ -1,14 +1,12 @@
-import { FRAGMENT } from "./types";
-import { h } from "./h";
-import type { VNode } from "./types";
+import { childVNodes, vnode } from "./h";
+import { FRAGMENT, type Key, type VNode } from "./types";
 
 export { FRAGMENT as Fragment };
 export type { JSX } from "./types";
 
 export function jsx(type: VNode["type"], props: Record<string, unknown> | null, key?: string | number): VNode {
-  const p = props ? { ...props } : {};
-  if (key !== undefined) p.key = key;
-  return h(type, p);
+  const p = props ?? {};
+  return vnode(type, p, childVNodes(p.children), key !== undefined ? key : (p.key as Key | undefined));
 }
 
 export const jsxs = jsx;

--- a/packages/svenjs/src/runtime.ts
+++ b/packages/svenjs/src/runtime.ts
@@ -135,20 +135,22 @@ export function flushSync(fn?: () => void) {
   if (failed) throw failure;
 }
 
-function collectDom(vnode: VNode | null | undefined): Node[] {
-  if (!vnode) return [];
-  if (isSpec(vnode.type) && vnode._instance) {
-    if (vnode._instance._vnode) return collectDom(vnode._instance._vnode);
-    return vnode._instance._placeholder ? [vnode._instance._placeholder] : [];
+function lastNode(vnode: VNode | null | undefined): Node | null {
+  return vnode?._end ?? vnode?._dom ?? null;
+}
+
+function moveVNode(parent: Node, vnode: VNode, next: Node | null) {
+  const start = vnode._dom;
+  if (!start) return;
+  const end = vnode._end ?? start;
+  if (end.nextSibling === next) return;
+  let node: Node | null = start;
+  while (node) {
+    const following: Node | null = node.nextSibling;
+    parent.insertBefore(node, next);
+    if (node === end) break;
+    node = following;
   }
-  if (vnode.type === FRAGMENT) {
-    const out: Node[] = [];
-    if (vnode._dom) out.push(vnode._dom);
-    for (const c of vnode.children) out.push(...collectDom(c));
-    if (vnode._end) out.push(vnode._end);
-    return out;
-  }
-  return vnode._dom ? [vnode._dom] : [];
 }
 
 function renderInstance(inst: Instance): VNode | null {
@@ -288,7 +290,7 @@ function patch(parent: Node, oldV: VNode | null | undefined, newV: VNode | null 
     return;
   }
   if (oldV.type !== newV.type) {
-    const anchor = collectDom(oldV).pop()?.nextSibling ?? null;
+    const anchor = lastNode(oldV)?.nextSibling ?? null;
     unmount(oldV);
     mount(newV, parent, anchor, svg);
     return;
@@ -337,7 +339,7 @@ function patchRendered(inst: Instance, rendered: VNode | null, svg: boolean) {
     inst._placeholder?.parentNode?.removeChild(inst._placeholder);
     inst._placeholder = null;
   } else if (old && !rendered) {
-    const anchor = collectDom(old).pop()?.nextSibling ?? null;
+    const anchor = lastNode(old)?.nextSibling ?? null;
     unmount(old);
     inst._placeholder = document.createComment("");
     parent.insertBefore(inst._placeholder, anchor);
@@ -380,25 +382,33 @@ function updateInstance(inst: Instance) {
 }
 
 function patchChildren(parent: Node, oldCh: VNode[], newCh: VNode[], svg = false, boundary: Node | null = null) {
-  const oldList = oldCh.filter(Boolean);
-  const newList = newCh.filter(Boolean);
-  if (import.meta.env.DEV) warnKeys(newList);
+  if (import.meta.env.DEV) warnKeys(newCh);
+
+  const oldLen = oldCh.length;
+  const newLen = newCh.length;
+  if (oldLen === newLen && oldLen) {
+    let i = 0;
+    for (; i < oldLen; i++) if (oldCh[i].key == null || oldCh[i].key !== newCh[i].key) break;
+    if (i === oldLen) {
+      for (let j = 0; j < newLen; j++) patch(parent, oldCh[j], newCh[j], svg);
+      return;
+    }
+  }
 
   const oldByKey = new Map<string | number, VNode>();
-  for (const o of oldList) {
+  for (const o of oldCh) {
     if (o.key != null) oldByKey.set(o.key, o);
   }
 
   const used = new Set<VNode>();
 
-  for (const n of newList) {
+  for (const n of newCh) {
     let match: VNode | undefined;
     if (n.key != null) {
       const keyed = oldByKey.get(n.key);
       if (keyed && keyed.type === n.type) match = keyed;
-    }
-    if (!match) {
-      match = oldList.find((o) => !used.has(o) && o.key == null && o.type === n.type);
+    } else {
+      match = oldCh.find((o) => !used.has(o) && o.key == null && o.type === n.type);
     }
     if (match) {
       used.add(match);
@@ -408,19 +418,15 @@ function patchChildren(parent: Node, oldCh: VNode[], newCh: VNode[], svg = false
     }
   }
 
-  for (const o of oldList) {
+  for (const o of oldCh) {
     if (!used.has(o)) unmount(o);
   }
 
   let next = boundary;
-  for (let i = newList.length - 1; i >= 0; i--) {
-    const nodes = collectDom(newList[i]);
-    if (!nodes.length) continue;
-    const first = nodes[0];
-    if (nodes[nodes.length - 1].nextSibling !== next) {
-      for (const node of nodes) parent.insertBefore(node, next);
-    }
-    next = first;
+  for (let i = newLen - 1; i >= 0; i--) {
+    const vnode = newCh[i];
+    moveVNode(parent, vnode, next);
+    if (vnode._dom) next = vnode._dom;
   }
 }
 
@@ -546,7 +552,7 @@ export function unmountRoot(container: Element) {
 }
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return s.replace(/[&<>"]/g, (ch) => (ch === "&" ? "&amp;" : ch === "<" ? "&lt;" : ch === ">" ? "&gt;" : "&quot;"));
 }
 
 function attrsToString(props: Record<string, any>): string {
@@ -590,19 +596,24 @@ function attrsToString(props: Record<string, any>): string {
 function stringify(vnode: VNode | null): string {
   if (!vnode) return "";
   if (vnode.type === TEXT) return escapeHtml(String(vnode.props.nodeValue ?? ""));
-  if (vnode.type === FRAGMENT) return vnode.children.map(stringify).join("");
+  if (vnode.type === FRAGMENT) {
+    let out = "";
+    for (const c of vnode.children) out += stringify(c);
+    return out;
+  }
   if (isSpec(vnode.type)) {
     const inst = makeInstance(vnode.type, vnode.props);
     callHook(inst, "onBeforeMount", "_beforeMount");
-    const rendered = renderInstance(inst);
-    return stringify(rendered);
+    return stringify(renderInstance(inst));
   }
   const tag = vnode.type as string;
   if (!validAttributeName(tag)) throw new TypeError("SvenJS: bad tag");
   const inner = vnode.props.dangerouslySetInnerHTML?.__html;
   const open = `<${tag}${attrsToString(vnode.props)}>`;
   if (VOID.has(tag)) return open;
-  const body = inner != null ? String(inner) : vnode.children.map(stringify).join("");
+  if (inner != null) return `${open}${String(inner)}</${tag}>`;
+  let body = "";
+  for (const c of vnode.children) body += stringify(c);
   return `${open}${body}</${tag}>`;
 }
 

--- a/packages/svenjs/src/runtime.ts
+++ b/packages/svenjs/src/runtime.ts
@@ -135,14 +135,28 @@ export function flushSync(fn?: () => void) {
   if (failed) throw failure;
 }
 
-function lastNode(vnode: VNode | null | undefined): Node | null {
-  return vnode?._end ?? vnode?._dom ?? null;
+function liveStart(vnode: VNode | null | undefined): Node | null {
+  if (!vnode) return null;
+  if (isSpec(vnode.type) && vnode._instance) {
+    const inst = vnode._instance;
+    return inst._vnode ? liveStart(inst._vnode) : inst._placeholder;
+  }
+  return vnode._dom ?? null;
+}
+
+function liveEnd(vnode: VNode | null | undefined): Node | null {
+  if (!vnode) return null;
+  if (isSpec(vnode.type) && vnode._instance) {
+    const inst = vnode._instance;
+    return inst._vnode ? liveEnd(inst._vnode) : inst._placeholder;
+  }
+  return vnode._end ?? vnode._dom ?? null;
 }
 
 function moveVNode(parent: Node, vnode: VNode, next: Node | null) {
-  const start = vnode._dom;
+  const start = liveStart(vnode);
   if (!start) return;
-  const end = vnode._end ?? start;
+  const end = liveEnd(vnode) ?? start;
   if (end.nextSibling === next) return;
   let node: Node | null = start;
   while (node) {
@@ -290,7 +304,7 @@ function patch(parent: Node, oldV: VNode | null | undefined, newV: VNode | null 
     return;
   }
   if (oldV.type !== newV.type) {
-    const anchor = lastNode(oldV)?.nextSibling ?? null;
+    const anchor = liveEnd(oldV)?.nextSibling ?? null;
     unmount(oldV);
     mount(newV, parent, anchor, svg);
     return;
@@ -339,7 +353,7 @@ function patchRendered(inst: Instance, rendered: VNode | null, svg: boolean) {
     inst._placeholder?.parentNode?.removeChild(inst._placeholder);
     inst._placeholder = null;
   } else if (old && !rendered) {
-    const anchor = lastNode(old)?.nextSibling ?? null;
+    const anchor = liveEnd(old)?.nextSibling ?? null;
     unmount(old);
     inst._placeholder = document.createComment("");
     parent.insertBefore(inst._placeholder, anchor);
@@ -351,6 +365,9 @@ function patchRendered(inst: Instance, rendered: VNode | null, svg: boolean) {
 
 function assignBoundary(vnode: VNode, inst: Instance) {
   const rendered = inst._vnode;
+  if (rendered && isSpec(rendered.type) && rendered._instance) {
+    assignBoundary(rendered, rendered._instance);
+  }
   vnode._dom = rendered?._dom ?? inst._placeholder;
   vnode._end = rendered?._end ?? null;
 }
@@ -426,7 +443,8 @@ function patchChildren(parent: Node, oldCh: VNode[], newCh: VNode[], svg = false
   for (let i = newLen - 1; i >= 0; i--) {
     const vnode = newCh[i];
     moveVNode(parent, vnode, next);
-    if (vnode._dom) next = vnode._dom;
+    const start = liveStart(vnode);
+    if (start) next = start;
   }
 }
 

--- a/packages/svenjs/tests/advanced-runtime.test.tsx
+++ b/packages/svenjs/tests/advanced-runtime.test.tsx
@@ -193,6 +193,31 @@ describe("DOM patch details", () => {
   });
 });
 
+describe("svg attributes", () => {
+  it("patches polyline points through the attribute, not the SVGPointList", () => {
+    const App = create({
+      initialState: { points: "0,0 10,10" },
+      render() {
+        return (
+          <div>
+            <svg>
+              <polyline className="line" points={this.state.points} />
+            </svg>
+            <button onClick={() => this.setState({ points: "0,0 20,5" })}>go</button>
+          </div>
+        );
+      },
+    });
+    const host = root();
+    render(App, host);
+    const line = host.querySelector(".line")!;
+    expect(line.getAttribute("points")).toBe("0,0 10,10");
+    (host.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(line.getAttribute("points")).toBe("0,0 20,5");
+  });
+});
+
 describe("hydration", () => {
   it("restores a controlled select value after adopting its options", () => {
     const node = (
@@ -437,6 +462,115 @@ describe("observe", () => {
     flushSync();
     expect(renders).toEqual([1]);
     expect(host.textContent).toBe("1");
+  });
+});
+
+describe("keyed patch throughput", () => {
+  it("does not move keyed children that kept their order", () => {
+    const App = create({
+      initialState: { ids: ["a", "b", "c"], n: 0 },
+      render() {
+        return (
+          <div>
+            <ul>
+              {this.state.ids.map((id: string) => (
+                <li key={id}>
+                  {id}:{this.state.n}
+                </li>
+              ))}
+            </ul>
+            <button onClick={() => this.setState({ ...this.state, n: 1 })}>go</button>
+          </div>
+        );
+      },
+    });
+    const host = root();
+    render(App, host);
+    const ul = host.querySelector("ul")!;
+    const spy = vi.spyOn(ul, "insertBefore");
+    (host.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(spy).not.toHaveBeenCalled();
+    expect([...ul.querySelectorAll("li")].map((n) => n.textContent)).toEqual(["a:1", "b:1", "c:1"]);
+  });
+
+  it("moves a fragment component as a contiguous range", () => {
+    const Pair = create<{ id: string }>({
+      render() {
+        return (
+          <>
+            <i data-pair={this.props.id}>{this.props.id}</i>
+            <b data-pair={this.props.id}>{this.props.id}</b>
+          </>
+        );
+      },
+    });
+    const App = create({
+      initialState: { ids: ["a", "b"] },
+      render() {
+        return (
+          <div>
+            <span>
+              {this.state.ids.map((id: string) => (
+                <Pair key={id} id={id} />
+              ))}
+            </span>
+            <button onClick={() => this.setState({ ids: ["b", "a"] })}>go</button>
+          </div>
+        );
+      },
+    });
+    const host = root();
+    render(App, host);
+    const aI = host.querySelector('i[data-pair="a"]')!;
+    const aB = host.querySelector('b[data-pair="a"]')!;
+    const bI = host.querySelector('i[data-pair="b"]')!;
+    const bB = host.querySelector('b[data-pair="b"]')!;
+    (host.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    const nodes = [...host.querySelector("span")!.childNodes].filter((n) => n.nodeType === 1);
+    expect(nodes.map((n) => `${(n as Element).tagName}:${(n as Element).textContent}`)).toEqual([
+      "I:b",
+      "B:b",
+      "I:a",
+      "B:a",
+    ]);
+    expect(host.querySelector('i[data-pair="a"]')).toBe(aI);
+    expect(host.querySelector('b[data-pair="a"]')).toBe(aB);
+    expect(host.querySelector('i[data-pair="b"]')).toBe(bI);
+    expect(host.querySelector('b[data-pair="b"]')).toBe(bB);
+    expect(bI.nextSibling).toBe(bB);
+    expect(aI.nextSibling).toBe(aB);
+  });
+
+  it("mounts a keyed node instead of stealing an unkeyed node of the same type", () => {
+    const mounts: string[] = [];
+    const Item = create<{ id: string }>({
+      onMount() {
+        mounts.push(this.props.id);
+      },
+      render() {
+        return <span data-id={this.props.id}>{this.props.id}</span>;
+      },
+    });
+    const App = create({
+      initialState: { keyed: false },
+      render() {
+        return (
+          <div>
+            <p>{this.state.keyed ? <Item key="x" id="x" /> : <Item id="old" />}</p>
+            <button onClick={() => this.setState({ keyed: true })}>go</button>
+          </div>
+        );
+      },
+    });
+    const host = root();
+    render(App, host);
+    expect(mounts).toEqual(["old"]);
+    (host.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(mounts).toEqual(["old", "x"]);
+    expect(host.querySelector("span")?.textContent).toBe("x");
   });
 });
 

--- a/packages/svenjs/tests/advanced-runtime.test.tsx
+++ b/packages/svenjs/tests/advanced-runtime.test.tsx
@@ -543,6 +543,68 @@ describe("keyed patch throughput", () => {
     expect(aI.nextSibling).toBe(aB);
   });
 
+  it("moves a nested component after it independently changes its root", () => {
+    const inners: Array<{ props: { id: string }; setState: (s: { split: boolean }) => void }> = [];
+    const Inner = create<{ id: string }, { split: boolean }>({
+      initialState: { split: false },
+      onMount() {
+        inners.push(this);
+      },
+      render() {
+        return this.state.split ? (
+          <>
+            <i data-id={this.props.id}>{this.props.id}</i>
+            <b data-id={this.props.id}>{this.props.id}</b>
+          </>
+        ) : (
+          <span data-id={this.props.id}>{this.props.id}</span>
+        );
+      },
+    });
+    const Wrap = create<{ id: string }>({
+      render() {
+        return <Inner id={this.props.id} />;
+      },
+    });
+    const App = create({
+      initialState: { ids: ["a", "b"] },
+      render() {
+        return (
+          <div>
+            <p>
+              {this.state.ids.map((id: string) => (
+                <Wrap key={id} id={id} />
+              ))}
+            </p>
+            <button onClick={() => this.setState({ ids: ["b", "a"] })}>go</button>
+          </div>
+        );
+      },
+    });
+    const host = root();
+    render(App, host);
+    inners.find((item) => item.props.id === "a")!.setState({ split: true });
+    flushSync();
+    const aI = host.querySelector('i[data-id="a"]')!;
+    const aB = host.querySelector('b[data-id="a"]')!;
+    const bSpan = host.querySelector('span[data-id="b"]')!;
+    expect(host.querySelector("span[data-id='a']")).toBeNull();
+    (host.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    const nodes = [...host.querySelector("p")!.childNodes].filter((n) => n.nodeType === 1);
+    expect(nodes.map((n) => `${(n as Element).tagName}:${(n as Element).textContent}`)).toEqual([
+      "SPAN:b",
+      "I:a",
+      "B:a",
+    ]);
+    expect(host.querySelector('i[data-id="a"]')).toBe(aI);
+    expect(host.querySelector('b[data-id="a"]')).toBe(aB);
+    expect(host.querySelector('span[data-id="b"]')).toBe(bSpan);
+    expect(aI.nextSibling).toBe(aB);
+    expect(aI.isConnected).toBe(true);
+    expect(bSpan.isConnected).toBe(true);
+  });
+
   it("mounts a keyed node instead of stealing an unkeyed node of the same type", () => {
     const mounts: string[] = [];
     const Item = create<{ id: string }>({

--- a/packages/svenjs/tests/runtime.test.tsx
+++ b/packages/svenjs/tests/runtime.test.tsx
@@ -283,6 +283,27 @@ describe("events + attrs", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the caret when a controlled value is unchanged", () => {
+    const App = create({
+      initialState: { n: 0 },
+      render() {
+        return (
+          <div>
+            <input value="same" />
+            <button onClick={() => this.setState({ n: this.state.n + 1 })}>x</button>
+          </div>
+        );
+      },
+    });
+    const rootEl = mount(App);
+    const input = rootEl.querySelector("input") as HTMLInputElement;
+    input.setSelectionRange(2, 2);
+    (rootEl.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(input.value).toBe("same");
+    expect(input.selectionStart).toBe(2);
+  });
+
   it("updates checked and value", () => {
     const App = create({
       initialState: { on: false, text: "a" },

--- a/packages/svenjs/tests/runtime.test.tsx
+++ b/packages/svenjs/tests/runtime.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { create, createStore, flushSync, h, render, renderToString, unmountRoot } from "svenjs";
+import { create, createStore, flushSync, h, jsx, render, renderToString, unmountRoot } from "svenjs";
 
 function mount(spec: Parameters<typeof render>[0]) {
   const root = document.createElement("div");
@@ -285,18 +285,19 @@ describe("events + attrs", () => {
 
   it("keeps the caret when a controlled value is unchanged", () => {
     const App = create({
-      initialState: { n: 0 },
+      initialState: { value: "before" },
       render() {
         return (
           <div>
-            <input value="same" />
-            <button onClick={() => this.setState({ n: this.state.n + 1 })}>x</button>
+            <input value={this.state.value} />
+            <button onClick={() => this.setState({ value: "same" })}>x</button>
           </div>
         );
       },
     });
     const rootEl = mount(App);
     const input = rootEl.querySelector("input") as HTMLInputElement;
+    input.value = "same";
     input.setSelectionRange(2, 2);
     (rootEl.querySelector("button") as HTMLButtonElement).click();
     flushSync();
@@ -403,5 +404,50 @@ describe("h hyperscript", () => {
     });
     const root = mount(App);
     expect(root.querySelector("#x")?.textContent).toBe("abc");
+  });
+
+  it("snapshots a reused props object between renders", () => {
+    const props = { id: "first" };
+    let instance: { setState(next: { id: string }): void } | undefined;
+    const App = create<Record<string, never>, { id: string }>({
+      initialState: { id: "first" },
+      onMount() {
+        instance = this;
+      },
+      render() {
+        props.id = this.state.id;
+        return h("div", props);
+      },
+    });
+    const root = mount(App);
+    expect(root.querySelector("div")?.id).toBe("first");
+
+    instance!.setState({ id: "second" });
+    flushSync();
+    expect(root.querySelector("div")?.id).toBe("second");
+  });
+
+  it("keeps empty child arrays isolated", () => {
+    const first = h("div", null);
+    const second = h("div", null);
+    first.children.push(h("span", null, "added"));
+    expect(second.children).toEqual([]);
+  });
+
+  it("keeps the automatic-runtime key on component props", () => {
+    const Item = create<{ key: string }>({
+      render() {
+        return <span>{this.props.key}</span>;
+      },
+    });
+    const root = mount(jsx(Item, {}, "row"));
+    expect(root.textContent).toBe("row");
+  });
+
+  it("snapshots props in the automatic JSX runtime", () => {
+    const props = { id: "first" };
+    const node = jsx("div", props);
+    props.id = "second";
+    expect(node.props.id).toBe("first");
   });
 });


### PR DESCRIPTION
## Summary

The 3.2 runtime was doing extra work on every update: allocating node arrays to decide that a keyed list had not moved, copying JSX props twice, rewriting style and `value` that had not changed, and (in Mission Control) rebinding 100 click listeners per telemetry tick.

This PR removes that work without changing the public API or observable vnode input semantics. IIFE gzip stays under the 5.5 kB budget (5267 / 5632).

## Runtime

**Keyed patch** (`packages/svenjs/src/runtime.ts`)
- Same-order keyed children patch in place: no `Map`/`Set`, no `insertBefore`, no per-child node arrays.
- `collectDom` is deleted. Moves walk `_dom`…`_end` as a contiguous range, resolving live boundaries through nested components, so fragments stay together when reordered even after an inner root changes.
- A new keyed node no longer steals an unkeyed sibling of the same type.

**Vnode create** (`h.ts`, `jsx-runtime.ts`)
- The automatic JSX runtime builds a vnode directly and snapshots props once instead of copying them again through `h()`.
- Public `h()` keeps its single props snapshot, compiler keys remain available on component props, and empty vnode child arrays remain isolated.
- `flatten()` handles already-filtered children directly. Arrays returned from `render()` become fragments without a rest spread.

**DOM writes** (`dom.ts`)
- Unchanged style keys skip `setProperty`.
- A DOM property is not assigned when it already matches (controlled `value` keeps the caret).
- `setAttribute` is still used for strings. Skipping it after a property write broke SVG `points` (`el.points` is an `SVGPointList`).

**SSR**
- One `escapeHtml` pass; `stringify` concatenates in a loop.

## Mission Control

One filter pass over the 100 units, in-place sort, and click delegation on `tbody` instead of a new `onClick` closure per row per tick.

## Docs

- `CHANGELOG.md` — full notes for this work.
- [Lists](apps/www/docs/lists.md) — same-order keys, mixed-key contract.
- [Rendering](apps/www/docs/rendering.md) — fragment ranges and style/`value`/SVG writes.

## Tests

- 59 unit tests, including: stable keyed lists without `insertBefore`, fragment-range reorder after nested root changes, keyed-vs-unkeyed remount, vnode props/children isolation, caret preservation, and SVG `points`.
- 15/15 Playwright e2e (stream, sort, filter, Inspect via delegation, one-file export).
- Workspace typecheck, production build/prerender, package-consumer typecheck, and size budget all pass.

## Invariants held

`setState` still replaces. Store/flush still snapshot listeners. Unkeyed type-matching is unchanged. ARIA/data booleans still serialize as `"true"`/`"false"`. Hydration, SVG namespaces, `select.value`-after-options, `h()`/JSX prop snapshots, and per-vnode child-array isolation are unchanged.
