### PR TITLE
chore: add verify CI, packed-tarball check, and 3.2.1 DOM baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm verify
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter www exec playwright install --with-deps chromium
+      - run: pnpm test:e2e

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,11 +21,7 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org/
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter svenjs test
-      - run: pnpm --filter svenjs typecheck
-      - run: pnpm --filter svenjs build
-      - run: pnpm --filter svenjs check:dist
-      - run: pnpm --filter svenjs size
-      - run: pnpm --filter svenjs publish --access public --no-git-checks
+      - run: pnpm verify
+      - run: pnpm --filter svenjs publish --access public --no-git-checks --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "pnpm --filter svenjs build && pnpm --filter www build",
     "test": "pnpm --filter svenjs test",
     "test:e2e": "pnpm --filter www test:e2e",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r typecheck",
+    "verify": "node ./scripts/verify.mjs"
   },
   "engines": {
     "node": ">=20",

--- a/packages/svenjs/package.json
+++ b/packages/svenjs/package.json
@@ -49,7 +49,8 @@
   ],
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json && node ./scripts/jsx-entries.mjs",
-    "prepublishOnly": "pnpm test && pnpm typecheck && pnpm build && pnpm check:dist && pnpm size",
+    "prepublishOnly": "pnpm test && pnpm typecheck && pnpm build && pnpm check:dist && pnpm size && pnpm check:pack",
+    "check:pack": "node ./scripts/check-pack.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/packages/svenjs/scripts/check-pack.mjs
+++ b/packages/svenjs/scripts/check-pack.mjs
@@ -1,0 +1,46 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkg = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dir = mkdtempSync(join(tmpdir(), "svenjs-pack-"));
+
+try {
+  execSync(`pnpm pack --pack-destination ${JSON.stringify(dir)}`, { cwd: pkg, stdio: "inherit" });
+  const tgz = readdirSync(dir).find((name) => name.endsWith(".tgz"));
+  if (!tgz) throw new Error("svenjs pack did not emit a tarball");
+
+  const consumer = join(dir, "consumer");
+  mkdirSync(consumer);
+  writeFileSync(
+    join(consumer, "package.json"),
+    JSON.stringify({ name: "svenjs-pack-consumer", type: "module", private: true }, null, 2),
+  );
+  writeFileSync(
+    join(consumer, "index.mjs"),
+    `import Svenjs, { create, html, renderToString, version } from "svenjs";
+
+if (typeof version !== "string" || !version) throw new Error("missing version");
+if (typeof document !== "undefined") throw new Error("pack check must run without a DOM");
+
+const App = create({
+  initialState: { n: 1 },
+  render() {
+    return html\`<p>\${this.state.n}</p>\`;
+  },
+});
+
+const out = renderToString(App);
+if (out !== "<p>1</p>") throw new Error("unexpected SSR: " + out);
+if (Svenjs.version !== version) throw new Error("default export version mismatch");
+console.log("pack-ok", version);
+`,
+  );
+
+  execSync(`npm install --omit=dev ${JSON.stringify(join(dir, tgz))}`, { cwd: consumer, stdio: "inherit" });
+  execSync("node index.mjs", { cwd: consumer, stdio: "inherit" });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/svenjs/tests/baseline-scenario.tsx
+++ b/packages/svenjs/tests/baseline-scenario.tsx
@@ -1,0 +1,54 @@
+import { create, flushSync, render, unmountRoot } from "svenjs";
+
+type Item = { id: number; t: string };
+
+/** Fixed mount / same-order patch / reorder / remove scenario used for DOM-op baselines. */
+export function runBaselineScenario(container: Element) {
+  let setItems: ((items: Item[]) => void) | undefined;
+  const App = create<{}, { items: Item[] }>({
+    initialState: {
+      items: [
+        { id: 1, t: "a" },
+        { id: 2, t: "b" },
+        { id: 3, t: "c" },
+      ],
+    },
+    onMount() {
+      setItems = (items) => this.setState({ items });
+    },
+    render() {
+      return (
+        <ul>
+          {this.state.items.map((item) => (
+            <li key={item.id}>{item.t}</li>
+          ))}
+        </ul>
+      );
+    },
+  });
+
+  render(App, container);
+  if (!setItems) throw new Error("baseline: missing instance");
+
+  setItems([
+    { id: 1, t: "a" },
+    { id: 2, t: "B" },
+    { id: 3, t: "c" },
+  ]);
+  flushSync();
+
+  setItems([
+    { id: 3, t: "c" },
+    { id: 1, t: "a" },
+    { id: 2, t: "B" },
+  ]);
+  flushSync();
+
+  setItems([
+    { id: 3, t: "c" },
+    { id: 1, t: "a" },
+  ]);
+  flushSync();
+
+  unmountRoot(container);
+}

--- a/packages/svenjs/tests/baseline.test.ts
+++ b/packages/svenjs/tests/baseline.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { runBaselineScenario } from "./baseline-scenario";
+import { countDomOps } from "./dom-ops";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const recorded = JSON.parse(readFileSync(resolve(here, "baseline/3.2.1.json"), "utf8")) as {
+  version: string;
+  size: { "svenjs.iife.js": { gzip: number } };
+  iifeGzipBudget: number;
+  domOps: Record<string, number>;
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("DOM-op baseline", () => {
+  it("matches the recorded mount/update/reorder/remove scenario", () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const ops = countDomOps(() => runBaselineScenario(root));
+    expect(ops).toEqual(recorded.domOps);
+  });
+});

--- a/packages/svenjs/tests/baseline/3.2.1.json
+++ b/packages/svenjs/tests/baseline/3.2.1.json
@@ -1,0 +1,20 @@
+{
+  "version": "3.2.1",
+  "commit": "1180ff4",
+  "environment": "happy-dom via Vitest, Node 20, macos/linux CI",
+  "size": {
+    "svenjs.js": { "raw": 19070, "gzip": 5826 },
+    "svenjs.iife.js": { "raw": 14144, "gzip": 5267 }
+  },
+  "iifeGzipBudget": 5632,
+  "laterIifeGzipBudget": 6144,
+  "domOps": {
+    "insertBefore": 9,
+    "removeChild": 2,
+    "createElement": 8,
+    "createTextNode": 3,
+    "setAttribute": 0,
+    "removeAttribute": 0
+  },
+  "notes": "DOM op counts are filled by tests/baseline.test.ts against runBaselineScenario. Wall-clock is not a CI gate."
+}

--- a/packages/svenjs/tests/dom-ops.ts
+++ b/packages/svenjs/tests/dom-ops.ts
@@ -1,0 +1,70 @@
+export type DomOps = {
+  insertBefore: number;
+  removeChild: number;
+  createElement: number;
+  createTextNode: number;
+  setAttribute: number;
+  removeAttribute: number;
+};
+
+const empty = (): DomOps => ({
+  insertBefore: 0,
+  removeChild: 0,
+  createElement: 0,
+  createTextNode: 0,
+  setAttribute: 0,
+  removeAttribute: 0,
+});
+
+function patchMethod(object: object, name: string, impl: (original: Function, args: unknown[]) => unknown): () => void {
+  const original = (object as Record<string, unknown>)[name];
+  if (typeof original !== "function") return () => {};
+  (object as Record<string, unknown>)[name] = function (this: unknown, ...args: unknown[]) {
+    return impl(original.bind(this), args);
+  };
+  return () => {
+    (object as Record<string, unknown>)[name] = original;
+  };
+}
+
+/** Count DOM writes during `fn`. Restores patched methods even if `fn` throws. */
+export function countDomOps(fn: () => void): DomOps {
+  const ops = empty();
+  const restore = [
+    patchMethod(Node.prototype, "insertBefore", (orig, args) => {
+      ops.insertBefore++;
+      return orig(...args);
+    }),
+    patchMethod(Node.prototype, "removeChild", (orig, args) => {
+      ops.removeChild++;
+      return orig(...args);
+    }),
+    patchMethod(document, "createElement", (orig, args) => {
+      ops.createElement++;
+      return orig(...args);
+    }),
+    patchMethod(document, "createElementNS", (orig, args) => {
+      ops.createElement++;
+      return orig(...args);
+    }),
+    patchMethod(document, "createTextNode", (orig, args) => {
+      ops.createTextNode++;
+      return orig(...args);
+    }),
+    patchMethod(Element.prototype, "setAttribute", (orig, args) => {
+      ops.setAttribute++;
+      return orig(...args);
+    }),
+    patchMethod(Element.prototype, "removeAttribute", (orig, args) => {
+      ops.removeAttribute++;
+      return orig(...args);
+    }),
+  ];
+
+  try {
+    fn();
+    return ops;
+  } finally {
+    for (const undo of restore) undo();
+  }
+}

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function run(title, command, args) {
+  console.log(`\n:: ${title}`);
+  const result = spawnSync(command, args, { cwd: root, stdio: "inherit" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+run("test", "pnpm", ["test"]);
+run("typecheck", "pnpm", ["typecheck"]);
+run("build", "pnpm", ["build"]);
+run("check:dist", "pnpm", ["--filter", "svenjs", "check:dist"]);
+run("size", "pnpm", ["--filter", "svenjs", "size"]);
+run("check:pack", "pnpm", ["--filter", "svenjs", "check:pack"]);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -11,8 +11,8 @@ function run(title, command, args) {
 }
 
 run("test", "pnpm", ["test"]);
-run("typecheck", "pnpm", ["typecheck"]);
 run("build", "pnpm", ["build"]);
+run("typecheck", "pnpm", ["typecheck"]);
 run("check:dist", "pnpm", ["--filter", "svenjs", "check:dist"]);
 run("size", "pnpm", ["--filter", "svenjs", "size"]);
 run("check:pack", "pnpm", ["--filter", "svenjs", "check:pack"]);


### PR DESCRIPTION
## Summary
Adds the 3.3 verification gate without changing runtime behavior: `pnpm verify`, PR/push CI, a packed-tarball consumer check, and a recorded 3.2.1 DOM-op/size baseline.

## Test plan
- [x] `pnpm --filter svenjs test`
- [x] `pnpm verify` after later stack PRs (this PR’s new `check:pack` runs against the 3.2.1 dist)

Stack: 1/4. Merge this before `svenjs-3.3/02-runtime`.