### PR TITLE
feat: isolate vnodes, commit lifecycle, forms, events, and stores

### DIFF
--- a/packages/svenjs/README.md
+++ b/packages/svenjs/README.md
@@ -25,6 +25,8 @@ Save as `hello.html` and open it. No npm.
 
 With a bundler: `npm install svenjs`, then JSX via `"jsxImportSource": "svenjs"`.
 
+Production files omit development checks. Bundlers that honor the `"development"` export condition load `svenjs.dev.js` automatically. A script tag that wants warnings should use `svenjs.iife.dev.js`; `NODE_ENV=development` cannot restore code already removed from the production build.
+
 For static HTML, render the same tree on both sides and hydrate it in the browser:
 
 ```jsx

--- a/packages/svenjs/package.json
+++ b/packages/svenjs/package.json
@@ -30,15 +30,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "development": "./dist/svenjs.dev.js",
       "import": "./dist/svenjs.js",
       "default": "./dist/svenjs.js"
     },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
+      "development": "./dist/jsx-runtime.dev.js",
       "import": "./dist/jsx-runtime.js"
     },
     "./jsx-dev-runtime": {
       "types": "./dist/jsx-dev-runtime.d.ts",
+      "development": "./dist/jsx-dev-runtime.dev.js",
       "import": "./dist/jsx-dev-runtime.js"
     }
   },
@@ -48,13 +51,13 @@
     "README.md"
   ],
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json && node ./scripts/jsx-entries.mjs",
+    "build": "vite build && SVEN_DEV=1 vite build && tsc -p tsconfig.build.json && node ./scripts/jsx-entries.mjs",
     "prepublishOnly": "pnpm test && pnpm typecheck && pnpm build && pnpm check:dist && pnpm size && pnpm check:pack",
     "check:pack": "node ./scripts/check-pack.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "check:dist": "tsc -p tests/fixtures/nodenext/tsconfig.json",
+    "check:dist": "tsc -p tests/fixtures/nodenext/tsconfig.json && tsc -p tests/fixtures/types/tsconfig.json",
     "size": "node ../../scripts/size.mjs"
   },
   "devDependencies": {

--- a/packages/svenjs/scripts/jsx-entries.mjs
+++ b/packages/svenjs/scripts/jsx-entries.mjs
@@ -3,9 +3,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const dist = resolve(dirname(fileURLToPath(import.meta.url)), "../dist");
-const src = `export { Fragment, jsx, jsxDEV, jsxs } from "./svenjs.js";\n`;
-writeFileSync(resolve(dist, "jsx-runtime.js"), src);
-writeFileSync(resolve(dist, "jsx-dev-runtime.js"), src);
+writeFileSync(resolve(dist, "jsx-runtime.js"), `export { Fragment, jsx, jsxDEV, jsxs } from "./svenjs.js";\n`);
+writeFileSync(resolve(dist, "jsx-dev-runtime.js"), `export { Fragment, jsx, jsxDEV, jsxs } from "./svenjs.js";\n`);
+writeFileSync(resolve(dist, "jsx-runtime.dev.js"), `export { Fragment, jsx, jsxDEV, jsxs } from "./svenjs.dev.js";\n`);
+writeFileSync(resolve(dist, "jsx-dev-runtime.dev.js"), `export { Fragment, jsx, jsxDEV, jsxs } from "./svenjs.dev.js";\n`);
 
 // TypeScript emits the source's extensionless imports verbatim. They are valid
 // with "bundler" resolution, but not in ESM projects using NodeNext/Node16.

--- a/packages/svenjs/src/create.ts
+++ b/packages/svenjs/src/create.ts
@@ -1,6 +1,8 @@
-import { SPEC, type ComponentSpec, type SvenComponent } from "./types";
+import { SPEC, type Component, type ComponentSpec, type SvenComponent } from "./types";
 
-export function create<P = any, S = any>(spec: ComponentSpec<P, S>): SvenComponent<P, S> {
+export function create<P = any, S = any>(
+  spec: ComponentSpec<P, S> & Record<string, any> & ThisType<Component<P, S> & Record<string, any>>,
+): SvenComponent<P, S> {
   if (typeof spec.render !== "function") {
     throw new Error("SvenJS: create() requires a render() method");
   }

--- a/packages/svenjs/src/dom.ts
+++ b/packages/svenjs/src/dom.ts
@@ -18,9 +18,12 @@ export function validAttributeName(name: string): boolean {
   return Boolean(name) && !INVALID_ATTRIBUTE.test(name);
 }
 
-function eventName(prop: string): string | null {
-  if (prop.length < 3 || prop[0] !== "o" || prop[1] !== "n") return null;
-  return prop.toLowerCase().slice(2);
+export function eventName(prop: string): string | null {
+  if (prop.length < 3) return null;
+  const lower = prop.toLowerCase();
+  if (lower[0] !== "o" || lower[1] !== "n") return null;
+  const rest = lower.slice(2);
+  return rest === "doubleclick" ? "dblclick" : rest;
 }
 
 function listeners(el: Element): ListenerMap {

--- a/packages/svenjs/src/freeze.ts
+++ b/packages/svenjs/src/freeze.ts
@@ -1,5 +1,10 @@
+function skipFreeze(o: object) {
+  return ArrayBuffer.isView(o) || o instanceof Date || o instanceof Map || o instanceof Set;
+}
+
 export function deepFreeze<T>(o: T): T {
   if (o === null || typeof o !== "object" || Object.isFrozen(o)) return o;
+  if (skipFreeze(o)) return o;
   Object.freeze(o);
   for (const key of Object.getOwnPropertyNames(o)) {
     deepFreeze((o as Record<string, unknown>)[key]);

--- a/packages/svenjs/src/h.ts
+++ b/packages/svenjs/src/h.ts
@@ -51,3 +51,16 @@ export function normalizeRender(output: unknown): VNode | null {
   if (Array.isArray(output)) return vnode(FRAGMENT, {}, flatten(output), undefined);
   return normalizeChild(output);
 }
+
+/** Copy a vnode tree without mount fields so cached `html` / reused `h` trees do not share `_dom`. */
+export function adopt(node: VNode | null): VNode | null {
+  if (!node) return null;
+  const from = node.children;
+  const n = from.length;
+  let children = from;
+  if (n) {
+    children = [];
+    for (let i = 0; i < n; i++) children[i] = adopt(from[i])!;
+  }
+  return vnode(node.type, node.props, children, node.key);
+}

--- a/packages/svenjs/src/runtime.ts
+++ b/packages/svenjs/src/runtime.ts
@@ -1,6 +1,6 @@
-import { applyRef, createDom, patchProps, styleText, SVG_NS, validAttributeName, VOID } from "./dom";
+import { applyRef, createDom, eventName, patchProps, styleText, SVG_NS, validAttributeName, VOID } from "./dom";
 import { freezeState } from "./freeze";
-import { normalizeRender } from "./h";
+import { adopt, normalizeRender } from "./h";
 import { FRAGMENT, SPEC, TEXT, type ComponentSpec, type Instance, type Observable, type VNode } from "./types";
 
 const queue = new Set<Instance>();
@@ -11,6 +11,49 @@ let sync = false;
 function callHook(inst: Instance, modern: string, legacy: string) {
   const fn = inst[modern] || inst[legacy];
   if (typeof fn === "function") fn.call(inst);
+}
+
+function runUser(fn: () => void, errors: unknown[]) {
+  try {
+    fn();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+function raise(errors: unknown[]) {
+  if (!errors.length) return;
+  for (let i = 1; i < errors.length; i++) console.error(errors[i]);
+  throw errors[0];
+}
+
+const mountQueue: Instance[] = [];
+let commitDepth = 0;
+
+function beginCommit() {
+  commitDepth++;
+}
+
+function abortCommit() {
+  mountQueue.length = 0;
+  commitDepth = 0;
+}
+
+function endCommit() {
+  if (--commitDepth !== 0) return;
+  const mounts = mountQueue.splice(0);
+  const errors: unknown[] = [];
+  for (let i = 0; i < mounts.length; i++) {
+    const inst = mounts[i];
+    if (inst._destroyed || !inst._mounted) continue;
+    runUser(() => callHook(inst, "onMount", "_didMount"), errors);
+  }
+  raise(errors);
+}
+
+function queueMount(inst: Instance) {
+  if (commitDepth) mountQueue.push(inst);
+  else callHook(inst, "onMount", "_didMount");
 }
 
 export function isSpec(value: unknown): value is ComponentSpec {
@@ -35,7 +78,7 @@ export function makeInstance(spec: ComponentSpec, props: Record<string, any>): I
 
   for (const key of Object.keys(spec)) {
     if (key === "initialState" || key === "props") continue;
-    const val = spec[key];
+    const val = (spec as Record<string, unknown>)[key];
     (inst as any)[key] = typeof val === "function" ? val.bind(inst) : val;
   }
 
@@ -87,8 +130,8 @@ export function schedule(inst: Instance) {
 export function flush() {
   scheduled = false;
   flushing = true;
-  let failed = false;
-  let failure: unknown;
+  const errors: unknown[] = [];
+  beginCommit();
   try {
     const list = [...queue];
     queue.clear();
@@ -97,18 +140,22 @@ export function flush() {
       try {
         updateInstance(inst);
       } catch (error) {
-        if (!failed) failure = error;
-        failed = true;
+        errors.push(error);
       }
     }
   } finally {
     flushing = false;
+    try {
+      endCommit();
+    } catch (error) {
+      errors.push(error);
+    }
     if (queue.size && !scheduled) {
       scheduled = true;
       queueMicrotask(flush);
     }
   }
-  if (failed) throw failure;
+  raise(errors);
 }
 
 export function flushSync(fn?: () => void) {
@@ -170,7 +217,7 @@ function moveVNode(parent: Node, vnode: VNode, next: Node | null) {
 function renderInstance(inst: Instance): VNode | null {
   inst._rendering = true;
   try {
-    return normalizeRender(inst.render());
+    return adopt(normalizeRender(inst.render()));
   } finally {
     inst._rendering = false;
   }
@@ -226,8 +273,14 @@ function mount(vnode: VNode, parent: Node, anchor: Node | null, svg = false) {
   vnode._dom = el;
   patchProps(el, {}, vnode.props);
   if (import.meta.env.DEV) warnKeys(vnode.children);
-  for (const child of vnode.children) mount(child, el, null, childSvg);
-  if (tag === "select" && vnode.props.value != null) (el as HTMLSelectElement).value = String(vnode.props.value);
+  if (vnode.props.dangerouslySetInnerHTML) {
+    if (import.meta.env.DEV && vnode.children.length) {
+      console.warn("SvenJS: dangerouslySetInnerHTML ignored children");
+    }
+  } else {
+    for (const child of vnode.children) mount(child, el, null, childSvg);
+  }
+  applyFormProps(el, tag, vnode.props);
   parent.insertBefore(el, anchor);
   applyRef(vnode.props, el);
 }
@@ -250,47 +303,42 @@ function mountComponent(vnode: VNode, parent: Node, anchor: Node | null, svg = f
   inst._mounted = true;
   vnode._dom = rendered?._dom ?? inst._placeholder;
   vnode._end = rendered?._end ?? null;
-  callHook(inst, "onMount", "_didMount");
+  queueMount(inst);
 }
 
-function unmount(vnode: VNode | null | undefined, removeDom = true) {
+function unmount(vnode: VNode | null | undefined, removeDom = true, errors?: unknown[]) {
   if (!vnode) return;
-
+  const owned = !errors;
+  const bag = errors ?? [];
   if (isSpec(vnode.type)) {
     const inst = vnode._instance;
     if (inst) {
       inst._destroyed = true;
       inst._mounted = false;
       if (inst._unsubs) {
-        for (const off of inst._unsubs) off();
+        for (const off of inst._unsubs) runUser(off, bag);
         inst._unsubs = null;
       }
-      callHook(inst, "onDestroy", "_willUnmount");
-      unmount(inst._vnode, removeDom);
+      runUser(() => callHook(inst, "onDestroy", "_willUnmount"), bag);
+      unmount(inst._vnode, removeDom, bag);
       if (removeDom) inst._placeholder?.parentNode?.removeChild(inst._placeholder);
       inst._vnode = null;
       inst._placeholder = null;
     }
-    return;
-  }
-
-  if (vnode.type === TEXT) {
+  } else if (vnode.type === TEXT) {
     if (removeDom) vnode._dom?.parentNode?.removeChild(vnode._dom);
-    return;
-  }
-
-  if (vnode.type === FRAGMENT) {
-    for (const c of vnode.children) unmount(c, removeDom);
+  } else if (vnode.type === FRAGMENT) {
+    for (const c of vnode.children) unmount(c, removeDom, bag);
     if (removeDom) {
       vnode._dom?.parentNode?.removeChild(vnode._dom);
       vnode._end?.parentNode?.removeChild(vnode._end);
     }
-    return;
+  } else {
+    runUser(() => applyRef(vnode.props, null), bag);
+    for (const c of vnode.children) unmount(c, false, bag);
+    if (removeDom) vnode._dom?.parentNode?.removeChild(vnode._dom);
   }
-
-  applyRef(vnode.props, null);
-  for (const c of vnode.children) unmount(c, false);
-  if (removeDom) vnode._dom?.parentNode?.removeChild(vnode._dom);
+  if (owned) raise(bag);
 }
 
 function patch(parent: Node, oldV: VNode | null | undefined, newV: VNode | null | undefined, svg = false) {
@@ -303,7 +351,7 @@ function patch(parent: Node, oldV: VNode | null | undefined, newV: VNode | null 
     mount(newV, parent, null, svg);
     return;
   }
-  if (oldV.type !== newV.type) {
+  if (oldV.type !== newV.type || oldV.key !== newV.key) {
     const anchor = liveEnd(oldV)?.nextSibling ?? null;
     unmount(oldV);
     mount(newV, parent, anchor, svg);
@@ -334,11 +382,23 @@ function patch(parent: Node, oldV: VNode | null | undefined, newV: VNode | null 
   newV._dom = el;
   const elementSvg = svg || newV.type === "svg";
   const childSvg = elementSvg && newV.type !== "foreignObject";
+  const oldHtml = oldV.props.dangerouslySetInnerHTML;
+  const newHtml = newV.props.dangerouslySetInnerHTML;
   patchProps(el, oldV.props, newV.props);
-  patchChildren(el, oldV.children, newV.children, childSvg);
-  if (newV.type === "select" && newV.props.value != null) {
-    (el as HTMLSelectElement).value = String(newV.props.value);
+  if (newHtml) {
+    if (!oldHtml) {
+      for (const c of oldV.children) unmount(c, false);
+    }
+    if (import.meta.env.DEV && newV.children.length) {
+      console.warn("SvenJS: dangerouslySetInnerHTML ignored children");
+    }
+  } else if (oldHtml) {
+    el.innerHTML = "";
+    for (const child of newV.children) mount(child, el, null, childSvg);
+  } else {
+    patchChildren(el, oldV.children, newV.children, childSvg);
   }
+  applyFormProps(el, newV.type as string, newV.props);
   if (oldV.props.ref !== newV.props.ref) {
     applyRef(oldV.props, null);
     applyRef(newV.props, el);
@@ -503,7 +563,7 @@ function hydrateVNode(vnode: VNode, parent: Node, node: Node | null, svg = false
     inst._mounted = true;
     vnode._dom = rendered?._dom ?? inst._placeholder;
     vnode._end = rendered?._end ?? null;
-    callHook(inst, "onMount", "_didMount");
+    queueMount(inst);
     return cursor;
   }
 
@@ -530,55 +590,87 @@ function hydrateVNode(vnode: VNode, parent: Node, node: Node | null, svg = false
       el.removeChild(cursor);
       cursor = next;
     }
+  } else if (import.meta.env.DEV && vnode.children.length) {
+    console.warn("SvenJS: dangerouslySetInnerHTML ignored children");
   }
-  if (tag === "select" && vnode.props.value != null) (el as HTMLSelectElement).value = String(vnode.props.value);
+  applyFormProps(el, tag, vnode.props);
   applyRef(vnode.props, el);
   return el.nextSibling;
 }
 
+function commitRoot(container: Element, next: VNode, prev: VNode | undefined, write: () => void) {
+  beginCommit();
+  try {
+    write();
+    ROOTS.set(container, next);
+  } catch (error) {
+    abortCommit();
+    if (!prev) {
+      try {
+        unmount(next);
+      } catch {
+        /* rollback */
+      }
+      ROOTS.delete(container);
+    }
+    throw error;
+  }
+  endCommit();
+}
+
 export function render(spec: ComponentSpec | VNode, container: Element | null): string | void {
   if (!container) return "Error: No node to attach";
-
-  const next = asRootVNode(spec);
-
+  const next = adopt(asRootVNode(spec))!;
   const prev = ROOTS.get(container);
-  if (prev) patch(container, prev, next);
-  else mount(next, container, null);
-  ROOTS.set(container, next);
+  commitRoot(container, next, prev, () => {
+    if (prev) patch(container, prev, next);
+    else mount(next, container, null);
+  });
 }
 
 export function hydrate(spec: ComponentSpec | VNode, container: Element | null): string | void {
   if (!container) return "Error: No node to attach";
   if (ROOTS.has(container)) return render(spec, container);
-
-  const next = asRootVNode(spec);
-  let cursor = hydrateVNode(next, container, container.firstChild);
-  while (cursor) {
-    const following = cursor.nextSibling;
-    container.removeChild(cursor);
-    cursor = following;
-  }
-  ROOTS.set(container, next);
+  const next = adopt(asRootVNode(spec))!;
+  commitRoot(container, next, undefined, () => {
+    let cursor = hydrateVNode(next, container, container.firstChild);
+    while (cursor) {
+      const following = cursor.nextSibling;
+      container.removeChild(cursor);
+      cursor = following;
+    }
+  });
 }
 
 export function unmountRoot(container: Element) {
   const prev = ROOTS.get(container);
-  if (prev) {
-    unmount(prev);
-    ROOTS.delete(container);
+  if (!prev) return;
+  ROOTS.delete(container);
+  unmount(prev);
+}
+
+function applyFormProps(el: Element, tag: string, props: Record<string, any>) {
+  if (tag === "textarea" && "value" in props) {
+    const next = props.value == null ? "" : String(props.value);
+    if ((el as HTMLTextAreaElement).value !== next) (el as HTMLTextAreaElement).value = next;
+  } else if (tag === "select" && props.value != null) {
+    (el as HTMLSelectElement).value = String(props.value);
   }
 }
+
+let selectedValue: unknown;
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"]/g, (ch) => (ch === "&" ? "&amp;" : ch === "<" ? "&lt;" : ch === ">" ? "&gt;" : "&quot;"));
 }
 
-function attrsToString(props: Record<string, any>): string {
+function attrsToString(props: Record<string, any>, tag?: string): string {
   let out = "";
   for (const name in props) {
     if (!validAttributeName(name)) continue;
     if (name === "key" || name === "children" || name === "ref" || name === "dangerouslySetInnerHTML") continue;
-    if (name[0] === "o" && name[1] === "n") continue;
+    if (eventName(name)) continue;
+    if ((tag === "textarea" || tag === "select") && name === "value") continue;
     if (name === "className" || name === "class") {
       if (name === "class" && props.className) continue;
       const c = props.className ?? props.class;
@@ -627,12 +719,35 @@ function stringify(vnode: VNode | null): string {
   const tag = vnode.type as string;
   if (!validAttributeName(tag)) throw new TypeError("SvenJS: bad tag");
   const inner = vnode.props.dangerouslySetInnerHTML?.__html;
-  const open = `<${tag}${attrsToString(vnode.props)}>`;
+  let extra = "";
+  if (tag === "option" && selectedValue != null) {
+    const value = vnode.props.value != null ? String(vnode.props.value) : textOf(vnode);
+    if (value === String(selectedValue)) extra = " selected";
+  }
+  const open = `<${tag}${attrsToString(vnode.props, tag)}${extra}>`;
   if (VOID.has(tag)) return open;
   if (inner != null) return `${open}${String(inner)}</${tag}>`;
+  if (tag === "textarea" && "value" in vnode.props) {
+    return `${open}${escapeHtml(String(vnode.props.value ?? ""))}</${tag}>`;
+  }
+  if (tag === "select") {
+    const prev = selectedValue;
+    selectedValue = vnode.props.value;
+    let body = "";
+    for (const c of vnode.children) body += stringify(c);
+    selectedValue = prev;
+    return `${open}${body}</${tag}>`;
+  }
   let body = "";
   for (const c of vnode.children) body += stringify(c);
   return `${open}${body}</${tag}>`;
+}
+
+function textOf(vnode: VNode): string {
+  if (vnode.type === TEXT) return String(vnode.props.nodeValue ?? "");
+  let out = "";
+  for (const c of vnode.children) out += textOf(c);
+  return out;
 }
 
 export function renderToString(spec: ComponentSpec | VNode): string {

--- a/packages/svenjs/src/store.ts
+++ b/packages/svenjs/src/store.ts
@@ -17,6 +17,18 @@ export function createStore<S = any>(spec: StoreSpec<S> = {}): Store<S> {
   const initial = (spec.state === undefined ? {} : spec.state) as S;
   let state = import.meta.env.DEV ? freezeState(initial) : initial;
   const listeners = new Set<(s: S) => void>();
+  let notifying = false;
+  const pending: S[] = [];
+
+  function notify(current: S, errors: unknown[]) {
+    for (const fn of [...listeners]) {
+      try {
+        fn(current);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+  }
 
   const store = {
     get() {
@@ -26,8 +38,22 @@ export function createStore<S = any>(spec: StoreSpec<S> = {}): Store<S> {
       const raw = typeof next === "function" ? (next as (s: S) => S)(state) : next;
       if (Object.is(raw, state)) return;
       state = import.meta.env.DEV ? freezeState(raw) : raw;
-      const current = state;
-      for (const fn of [...listeners]) fn(current);
+      if (notifying) {
+        pending.push(state);
+        return;
+      }
+      notifying = true;
+      const errors: unknown[] = [];
+      try {
+        notify(state, errors);
+        for (let i = 0; i < pending.length; i++) notify(pending[i], errors);
+        pending.length = 0;
+      } finally {
+        notifying = false;
+      }
+      if (!errors.length) return;
+      for (let i = 1; i < errors.length; i++) console.error(errors[i]);
+      throw errors[0];
     },
     subscribe(fn: (state: S) => void) {
       listeners.add(fn);

--- a/packages/svenjs/src/types.ts
+++ b/packages/svenjs/src/types.ts
@@ -13,20 +13,19 @@ export type Component<P = any, S = any> = {
   observe(store: Observable): () => void;
 };
 
-export type Host<P = any, S = any> = Component<P, S> & Record<string, any>;
+export type Host<P = any, S = any, M extends object = {}> = Component<P, S> & M;
 
 export type ComponentSpec<P = any, S = any> = {
   displayName?: string;
   initialState?: S | ((props: P) => S);
-  render(this: Host<P, S>): unknown;
-  onBeforeMount?(this: Host<P, S>): void;
-  onMount?(this: Host<P, S>): void;
-  onUpdate?(this: Host<P, S>): void;
-  onDestroy?(this: Host<P, S>): void;
-  _beforeMount?(this: Host<P, S>): void;
-  _didMount?(this: Host<P, S>): void;
-  _didUpdate?(this: Host<P, S>): void;
-  [key: string]: any;
+  render(): unknown;
+  onBeforeMount?(): void;
+  onMount?(): void;
+  onUpdate?(): void;
+  onDestroy?(): void;
+  _beforeMount?(): void;
+  _didMount?(): void;
+  _didUpdate?(): void;
 };
 
 export const FRAGMENT = Symbol.for("svenjs.fragment");
@@ -63,6 +62,30 @@ export type SvenComponent<P = any, S = any> = ComponentSpec<P, S> & {
   (props?: P): VNode;
 };
 
+type EventHandler<E extends Event> = (event: E) => void;
+
+export interface HTMLAttributes {
+  children?: unknown;
+  key?: Key;
+  class?: string;
+  className?: string;
+  id?: string;
+  style?: string | Record<string, string | number | undefined | null | false>;
+  ref?: (el: any) => void;
+  dangerouslySetInnerHTML?: { __html: string };
+  onClick?: EventHandler<MouseEvent>;
+  onDoubleClick?: EventHandler<MouseEvent>;
+  onDblClick?: EventHandler<MouseEvent>;
+  onInput?: EventHandler<InputEvent>;
+  onChange?: EventHandler<Event>;
+  onKeyDown?: EventHandler<KeyboardEvent>;
+  onKeyUp?: EventHandler<KeyboardEvent>;
+  onSubmit?: EventHandler<SubmitEvent>;
+  onFocus?: EventHandler<FocusEvent>;
+  onBlur?: EventHandler<FocusEvent>;
+  [attr: string]: any;
+}
+
 export namespace JSX {
   export type Element = VNode;
   export interface IntrinsicAttributes {
@@ -72,6 +95,6 @@ export namespace JSX {
     children: {};
   }
   export interface IntrinsicElements {
-    [elemName: string]: Props;
+    [elemName: string]: HTMLAttributes;
   }
 }

--- a/packages/svenjs/tests/cleanup.test.ts
+++ b/packages/svenjs/tests/cleanup.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { create, createStore, html, render, unmountRoot } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("unmount cleanup", () => {
+  it("finishes sibling cleanup when onDestroy throws", () => {
+    const log: string[] = [];
+    const Boom = create({
+      onDestroy() {
+        log.push("boom");
+        throw new Error("destroy-a");
+      },
+      render() {
+        return html`<p class="a">a</p>`;
+      },
+    });
+    const Ok = create({
+      onDestroy() {
+        log.push("ok");
+      },
+      render() {
+        return html`<p class="b">b</p>`;
+      },
+    });
+    const App = create({
+      render() {
+        return html`<div><${Boom} /><${Ok} /></div>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(() => unmountRoot(root)).toThrow("destroy-a");
+    expect(log).toEqual(["boom", "ok"]);
+    expect(root.querySelector("p")).toBeNull();
+  });
+
+  it("unsubscribes even when onDestroy throws", () => {
+    const store = createStore({ state: { n: 0 } });
+    let seen = 0;
+    const App = create({
+      onMount() {
+        this.observe(store);
+      },
+      onDestroy() {
+        throw new Error("nope");
+      },
+      render() {
+        seen += 1;
+        return html`<span>${store.get().n}</span>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(() => unmountRoot(root)).toThrow("nope");
+    store.set({ n: 1 });
+    expect(seen).toBe(1);
+  });
+
+  it("makes unmountRoot idempotent and allows remount after a thrown destroy", () => {
+    const App = create({
+      onDestroy() {
+        throw new Error("once");
+      },
+      render() {
+        return html`<p class="x">x</p>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(() => unmountRoot(root)).toThrow("once");
+    unmountRoot(root);
+    render(App, root);
+    expect(root.querySelector(".x")?.textContent).toBe("x");
+  });
+
+  it("runs remaining unsubscribe functions when one throws", () => {
+    const second = vi.fn();
+    const App = create({
+      onMount() {
+        this.observe({
+          subscribe() {
+            return () => {
+              throw new Error("unsub");
+            };
+          },
+        });
+        this.observe({
+          subscribe() {
+            return second;
+          },
+        });
+      },
+      render() {
+        return html`<i />`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(() => unmountRoot(root)).toThrow("unsub");
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/svenjs/tests/contract.test.tsx
+++ b/packages/svenjs/tests/contract.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { create, flushSync, h, html, render } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+const authors = {
+  html: (clicks: number, bump: () => void) =>
+    html`<button class="n" onClick=${bump}>${clicks}</button>`,
+  jsx: (clicks: number, bump: () => void) => (
+    <button className="n" onClick={bump}>
+      {clicks}
+    </button>
+  ),
+  h: (clicks: number, bump: () => void) => h("button", { class: "n", onClick: bump }, clicks),
+};
+
+describe.each(["html", "jsx", "h"] as const)("contract via %s", (author) => {
+  it("updates isolated instance state", () => {
+    const App = create({
+      initialState: { clicks: 0 },
+      render() {
+        return authors[author](this.state.clicks, () => this.setState({ clicks: this.state.clicks + 1 }));
+      },
+    });
+    const root = host();
+    render(App, root);
+    const btn = root.querySelector(".n") as HTMLButtonElement;
+    expect(btn.textContent).toBe("0");
+    btn.click();
+    flushSync();
+    expect(btn.textContent).toBe("1");
+    expect(root.querySelector(".n")).toBe(btn);
+  });
+});

--- a/packages/svenjs/tests/events.test.ts
+++ b/packages/svenjs/tests/events.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { create, flushSync, html, hydrate, render, renderToString, type VNode } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("events", () => {
+  it("maps onDoubleClick to native dblclick", () => {
+    const spy = vi.fn();
+    const App = create({
+      render() {
+        return html`<button onDoubleClick=${spy}>x</button>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    root.querySelector("button")!.dispatchEvent(new Event("dblclick"));
+    expect(spy).toHaveBeenCalledTimes(1);
+    root.querySelector("button")!.dispatchEvent(new Event("doubleclick"));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not serialize string event props as HTML attributes", () => {
+    const node = html`<button ONCLICK=${"alert(1)"} onClick=${"alert(2)"}>x</button>` as VNode;
+    expect(renderToString(node)).toBe("<button>x</button>");
+    const root = host();
+    render(node, root);
+    const btn = root.querySelector("button")!;
+    expect(btn.getAttribute("ONCLICK")).toBeNull();
+    expect(btn.getAttribute("onclick")).toBeNull();
+    expect(btn.getAttribute("onClick")).toBeNull();
+  });
+
+  it("replaces and removes listeners", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const App = create({
+      initialState: { which: "first" as "first" | "second" | "none" },
+      render() {
+        const handler = this.state.which === "first" ? first : this.state.which === "second" ? second : null;
+        return html`
+          <div>
+            <button class="target" onClick=${handler}>x</button>
+            <button class="next" onClick=${() =>
+              this.setState({
+                which: this.state.which === "first" ? "second" : "none",
+              })}
+            >
+              next
+            </button>
+          </div>
+        `;
+      },
+    });
+    const root = host();
+    render(App, root);
+    const target = root.querySelector(".target") as HTMLButtonElement;
+    target.click();
+    expect(first).toHaveBeenCalledTimes(1);
+    (root.querySelector(".next") as HTMLButtonElement).click();
+    flushSync();
+    target.click();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    (root.querySelector(".next") as HTMLButtonElement).click();
+    flushSync();
+    target.click();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips inline handlers during hydration", () => {
+    const spy = vi.fn();
+    const App = create({
+      render() {
+        return html`<button onClick=${spy}>x</button>`;
+      },
+    });
+    const root = host();
+    root.innerHTML = `<button onclick="throw new Error('inline')">x</button>`;
+    hydrate(App, root);
+    const btn = root.querySelector("button")!;
+    expect(btn.getAttribute("onclick")).toBeNull();
+    btn.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/svenjs/tests/fixtures/types/methods.tsx
+++ b/packages/svenjs/tests/fixtures/types/methods.tsx
@@ -1,0 +1,14 @@
+import { create } from "svenjs";
+
+const Counter = create({
+  initialState: { n: 0 },
+  add(n: number) {
+    this.setState({ n: this.state.n + n });
+  },
+  render() {
+    this.add(1);
+    return <button onClick={(e: MouseEvent) => this.add(e.button)}>{this.state.n}</button>;
+  },
+});
+
+void Counter;

--- a/packages/svenjs/tests/fixtures/types/tsconfig.json
+++ b/packages/svenjs/tests/fixtures/types/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "svenjs",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "paths": {
+      "svenjs": ["../../../src/index.ts"],
+      "svenjs/jsx-runtime": ["../../../src/jsx-runtime.ts"],
+      "svenjs/jsx-dev-runtime": ["../../../src/jsx-runtime.ts"]
+    }
+  },
+  "files": ["methods.tsx"]
+}

--- a/packages/svenjs/tests/forms.test.ts
+++ b/packages/svenjs/tests/forms.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { create, flushSync, html, hydrate, render, renderToString } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("forms", () => {
+  it("serializes textarea value as text content", () => {
+    const App = create({
+      render() {
+        return html`<textarea value=${"saved"}></textarea>`;
+      },
+    });
+    expect(renderToString(App)).toBe("<textarea>saved</textarea>");
+  });
+
+  it("serializes the matching select option as selected", () => {
+    const App = create({
+      render() {
+        return html`<select value=${"second"}><option value=${"first"}>First</option><option value=${"second"}>Second</option></select>`;
+      },
+    });
+    const markup = renderToString(App);
+    expect(markup).toContain("<option value=\"second\" selected>Second</option>");
+    expect(markup).not.toContain("<select value=");
+  });
+
+  it("hydrates textarea and select to the same values as client mount", () => {
+    const App = create({
+      render() {
+        return html`<form>
+          <textarea value=${"saved"}></textarea>
+          <select value=${"second"}>
+            <option value=${"first"}>First</option>
+            <option value=${"second"}>Second</option>
+          </select>
+        </form>`;
+      },
+    });
+    const markup = renderToString(App);
+    const server = host();
+    server.innerHTML = markup;
+    expect((server.querySelector("textarea") as HTMLTextAreaElement).textContent).toBe("saved");
+    expect(server.querySelector("option[selected]")?.getAttribute("value")).toBe("second");
+
+    hydrate(App, server);
+    expect((server.querySelector("textarea") as HTMLTextAreaElement).value).toBe("saved");
+    expect((server.querySelector("select") as HTMLSelectElement).value).toBe("second");
+    const area = server.querySelector("textarea");
+    const select = server.querySelector("select");
+
+    const client = host();
+    render(App, client);
+    expect((client.querySelector("textarea") as HTMLTextAreaElement).value).toBe("saved");
+    expect((client.querySelector("select") as HTMLSelectElement).value).toBe("second");
+    expect(server.querySelector("textarea")).toBe(area);
+    expect(server.querySelector("select")).toBe(select);
+  });
+
+  it("lets dangerouslySetInnerHTML win over children", () => {
+    const App = create({
+      initialState: { html: true },
+      render() {
+        return this.state.html
+          ? html`<div class="box" dangerouslySetInnerHTML=${{ __html: "<b>html</b>" }}><i>child</i></div>`
+          : html`<div class="box"><i>child</i></div>`;
+      },
+    });
+    expect(renderToString(App)).toBe('<div class="box"><b>html</b></div>');
+    const root = host();
+    render(App, root);
+    expect(root.querySelector(".box")?.innerHTML).toBe("<b>html</b>");
+    expect(root.querySelector("i")).toBeNull();
+  });
+
+  it("switches from children to innerHTML without leaving live children", () => {
+    const App = create({
+      initialState: { html: false },
+      render() {
+        return this.state.html
+          ? html`<div class="box" dangerouslySetInnerHTML=${{ __html: "<b>html</b>" }}></div>`
+          : html`<div class="box"><button onClick=${() => this.setState({ html: true })}>child</button></div>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(root.querySelector(".box")?.innerHTML).toBe("<b>html</b>");
+    expect(root.querySelector("button")).toBeNull();
+  });
+});

--- a/packages/svenjs/tests/identity.test.ts
+++ b/packages/svenjs/tests/identity.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { create, flushSync, h, html, hydrate, render, renderToString, unmountRoot } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+const Box = create({
+  render() {
+    return html`<p class="box">static</p>`;
+  },
+});
+
+describe("vnode ownership", () => {
+  it("keeps two sibling static html templates independent", () => {
+    const App = create({
+      initialState: { showFirst: true },
+      render() {
+        return html`
+          <div>
+            ${this.state.showFirst ? html`<${Box} key="first" />` : null}
+            <${Box} key="second" />
+            <button key="hide" onClick=${() => this.setState({ showFirst: false })}>hide</button>
+          </div>
+        `;
+      },
+    });
+
+    const root = host();
+    render(App, root);
+    const boxes = [...root.querySelectorAll(".box")];
+    expect(boxes).toHaveLength(2);
+    const second = boxes[1];
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(root.querySelectorAll(".box")).toHaveLength(1);
+    expect(root.querySelector(".box")).toBe(second);
+    expect(second.textContent).toBe("static");
+    expect(second.isConnected).toBe(true);
+  });
+
+  it("keeps two roots that share a static template independent", () => {
+    const a = host();
+    const b = host();
+    render(Box, a);
+    render(Box, b);
+    const nodeA = a.querySelector(".box");
+    const nodeB = b.querySelector(".box");
+    expect(nodeA).not.toBe(nodeB);
+    unmountRoot(a);
+    expect(a.querySelector(".box")).toBeNull();
+    expect(b.querySelector(".box")).toBe(nodeB);
+    expect(nodeB?.textContent).toBe("static");
+  });
+
+  it("does not share mount data when the same h() tree is rendered twice", () => {
+    const tree = h("p", { class: "once" }, "hi");
+    const a = host();
+    const b = host();
+    render(tree, a);
+    render(tree, b);
+    expect(a.querySelector(".once")).not.toBe(b.querySelector(".once"));
+    unmountRoot(a);
+    expect(b.querySelector(".once")?.textContent).toBe("hi");
+  });
+
+  it("hydrates and unmounts independent copies of a static template", () => {
+    const App = create({
+      render() {
+        return html`
+          <section>
+            <${Box} />
+            <${Box} />
+          </section>
+        `;
+      },
+    });
+    const markup = renderToString(App);
+    const root = host();
+    root.innerHTML = markup;
+    expect(root.querySelectorAll(".box")).toHaveLength(2);
+    hydrate(App, root);
+    const [first, second] = [...root.querySelectorAll(".box")];
+    expect(first).not.toBe(second);
+    unmountRoot(root);
+    expect(root.querySelector(".box")).toBeNull();
+  });
+
+  it("isolates a static subtree inside a dynamic parent", () => {
+    const App = create({
+      initialState: { n: 0 },
+      render() {
+        return html`
+          <div>
+            <span class="count">${this.state.n}</span>
+            ${html`<p class="static">keep</p>`}
+            <button onClick=${() => this.setState({ n: this.state.n + 1 })}>+</button>
+          </div>
+        `;
+      },
+    });
+    const root = host();
+    render(App, root);
+    const staticNode = root.querySelector(".static");
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(root.querySelector(".count")?.textContent).toBe("1");
+    expect(root.querySelector(".static")).toBe(staticNode);
+  });
+
+  it("remounts when a component root key changes", () => {
+    const Cell = create<{ id: string }>({
+      render() {
+        return html`<span key=${this.props.id} class="cell">${this.props.id}</span>`;
+      },
+    });
+    const App = create({
+      initialState: { id: "a" },
+      render() {
+        return html`
+          <div>
+            <${Cell} id=${this.state.id} />
+            <button onClick=${() => this.setState({ id: "b" })}>swap</button>
+          </div>
+        `;
+      },
+    });
+    const root = host();
+    render(App, root);
+    const first = root.querySelector(".cell");
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    const second = root.querySelector(".cell");
+    expect(second).not.toBe(first);
+    expect(second?.textContent).toBe("b");
+  });
+
+  it("moves keyed list siblings without remounting", () => {
+    const App = create({
+      initialState: { items: ["a", "b"] },
+      render() {
+        return html`
+          <div>
+            <ul>
+              ${this.state.items.map((id) => html`<li key=${id} class=${id}>${id}</li>`)}
+            </ul>
+            <button onClick=${() => this.setState({ items: ["b", "a"] })}>reorder</button>
+          </div>
+        `;
+      },
+    });
+    const root = host();
+    render(App, root);
+    const a = root.querySelector(".a");
+    const b = root.querySelector(".b");
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect(root.querySelector(".a")).toBe(a);
+    expect(root.querySelector(".b")).toBe(b);
+    expect([...root.querySelectorAll("li")].map((n) => n.textContent)).toEqual(["b", "a"]);
+  });
+
+  it("isolates fragment templates used twice", () => {
+    const Pair = create({
+      render() {
+        return [html`<i class="dot">x</i>`, html`<i class="dot">y</i>`];
+      },
+    });
+    const App = create({
+      initialState: { show: true },
+      render() {
+        return html`
+          <div>
+            ${this.state.show ? html`<${Pair} />` : null}
+            <${Pair} />
+            <button onClick=${() => this.setState({ show: false })}>hide</button>
+          </div>
+        `;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(root.querySelectorAll(".dot")).toHaveLength(4);
+    const kept = [...root.querySelectorAll(".dot")].slice(2);
+    (root.querySelector("button") as HTMLButtonElement).click();
+    flushSync();
+    expect([...root.querySelectorAll(".dot")]).toEqual(kept);
+  });
+});

--- a/packages/svenjs/tests/lifecycle.test.ts
+++ b/packages/svenjs/tests/lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { create, flushSync, html, render, renderToString, unmountRoot } from "svenjs";
+
+function host() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("lifecycle commit", () => {
+  it("runs nested onMount after the tree is inserted", () => {
+    const log: Array<{ name: string; connected: boolean }> = [];
+    const Field = create({
+      onMount() {
+        log.push({ name: "field", connected: this._input?.isConnected === true });
+      },
+      render() {
+        return html`<input ref=${(el: HTMLInputElement | null) => {
+          this._input = el;
+        }} />`;
+      },
+    });
+    const App = create({
+      onMount() {
+        log.push({ name: "app", connected: this._input?.isConnected === true });
+      },
+      render() {
+        return html`<div><${Field} /><span ref=${(el: HTMLElement | null) => {
+          this._input = el;
+        }}></span></div>`;
+      },
+    });
+    render(App, host());
+    expect(log[0]?.name).toBe("field");
+    expect(log[0]?.connected).toBe(true);
+    expect(log[1]?.name).toBe("app");
+    expect(log[1]?.connected).toBe(true);
+  });
+
+  it("runs onMount once per mount and setState from onMount does not re-run it", () => {
+    const log: string[] = [];
+    const App = create({
+      initialState: { n: 0 },
+      onMount() {
+        log.push("mount");
+        this.setState({ n: 1 });
+      },
+      onUpdate() {
+        log.push("update");
+      },
+      render() {
+        return html`<span>${this.state.n}</span>`;
+      },
+    });
+    const root = host();
+    render(App, root);
+    expect(log).toEqual(["mount"]);
+    flushSync();
+    expect(log).toEqual(["mount", "update"]);
+    expect(root.textContent).toBe("1");
+  });
+
+  it("still runs onMount on a detached root", () => {
+    let connected = true;
+    const App = create({
+      onMount() {
+        connected = this._el?.isConnected === true;
+      },
+      render() {
+        return html`<p ref=${(el: HTMLElement | null) => {
+          this._el = el;
+        }}>x</p>`;
+      },
+    });
+    const root = document.createElement("div");
+    render(App, root);
+    expect(connected).toBe(false);
+    expect(root.textContent).toBe("x");
+  });
+
+  it("does not run onMount during SSR", () => {
+    let mounted = false;
+    const App = create({
+      onBeforeMount() {
+        this.server = true;
+      },
+      onMount() {
+        mounted = true;
+      },
+      render() {
+        return html`<b>${this.server ? "ssr" : "client"}</b>`;
+      },
+    });
+    expect(renderToString(App)).toBe("<b>ssr</b>");
+    expect(mounted).toBe(false);
+  });
+
+  it("applies refs before onMount", () => {
+    const order: string[] = [];
+    const App = create({
+      onMount() {
+        order.push(this._el ? "mount-with-ref" : "mount-without-ref");
+      },
+      render() {
+        return html`<i
+          ref=${(el: HTMLElement | null) => {
+            this._el = el;
+            if (el) order.push("ref");
+          }}
+        ></i>`;
+      },
+    });
+    render(App, host());
+    expect(order).toEqual(["ref", "mount-with-ref"]);
+  });
+});

--- a/packages/svenjs/tests/runtime.test.tsx
+++ b/packages/svenjs/tests/runtime.test.tsx
@@ -36,8 +36,8 @@ describe("setState", () => {
       render() {
         return (
           <button
-            ref={(el: HTMLElement | null) => {
-              if (el) host = el;
+            ref={(el: Element | null) => {
+              if (el) host = el as HTMLElement;
             }}
             onClick={() => this.setState({ clicks: this.state.clicks + 1 })}
           >

--- a/packages/svenjs/tests/state.test.ts
+++ b/packages/svenjs/tests/state.test.ts
@@ -53,4 +53,56 @@ describe("state hardening", () => {
     store.set(2);
     expect(calls).toEqual(["a:1", "b:1", "a:2", "c:2"]);
   });
+
+  it("notifies remaining listeners when one throws", () => {
+    const store = createStore({ state: 0 });
+    const seen: number[] = [];
+    store.subscribe(() => {
+      throw new Error("boom");
+    });
+    store.subscribe((state) => {
+      seen.push(state);
+    });
+    expect(() => store.set(1)).toThrow("boom");
+    expect(seen).toEqual([1]);
+    expect(store.get()).toBe(1);
+  });
+
+  it("queues nested set so listeners see states in order", () => {
+    const store = createStore({ state: 0 });
+    const seen: Array<[string, number, number]> = [];
+    store.subscribe((state) => {
+      seen.push(["a", state, store.get()]);
+      if (state === 1) store.set(2);
+    });
+    store.subscribe((state) => {
+      seen.push(["b", state, store.get()]);
+    });
+    store.set(1);
+    expect(store.get()).toBe(2);
+    expect(seen).toEqual([
+      ["a", 1, 1],
+      ["b", 1, 2],
+      ["a", 2, 2],
+      ["b", 2, 2],
+    ]);
+  });
+
+  it("clones Map, Set, Date, and typed arrays without throwing", () => {
+    const store = createStore({
+      state: {
+        map: new Map([["a", { n: 1 }]]),
+        set: new Set([1]),
+        date: new Date("2020-01-01"),
+        bytes: new Uint8Array([1, 2, 3]),
+      },
+    });
+    const state = store.get();
+    state.map.set("b", { n: 2 });
+    state.set.add(2);
+    state.date.setFullYear(2021);
+    state.bytes[0] = 9;
+    expect(state.map.size).toBe(2);
+    expect(state.bytes[0]).toBe(9);
+  });
 });

--- a/packages/svenjs/vite.config.ts
+++ b/packages/svenjs/vite.config.ts
@@ -1,13 +1,25 @@
 import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
-export default defineConfig({
+const devBuild = process.env.SVEN_DEV === "1";
+
+export default defineConfig(({ command }) => ({
+  define:
+    command === "build"
+      ? {
+          "import.meta.env.DEV": JSON.stringify(devBuild),
+        }
+      : undefined,
   build: {
+    emptyOutDir: !devBuild,
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
       name: "Svenjs",
       formats: ["es", "iife"],
-      fileName: (format) => (format === "es" ? "svenjs.js" : "svenjs.iife.js"),
+      fileName: (format) => {
+        if (devBuild) return format === "es" ? "svenjs.dev.js" : "svenjs.iife.dev.js";
+        return format === "es" ? "svenjs.js" : "svenjs.iife.js";
+      },
     },
     sourcemap: true,
     minify: "esbuild",
@@ -28,4 +40,4 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
   },
-});
+}));

--- a/scripts/size.mjs
+++ b/scripts/size.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const dir = dirname(fileURLToPath(import.meta.url));
-const files = ["svenjs.js", "svenjs.iife.js"];
+const files = ["svenjs.js", "svenjs.iife.js", "svenjs.dev.js", "svenjs.iife.dev.js"];
 let failed = false;
 for (const name of files) {
   const file = resolve(dir, "../packages/svenjs/dist", name);
@@ -14,8 +14,8 @@ for (const name of files) {
   console.log(`${name.padEnd(16)} ${raw.length} bytes raw, ${gz.length} gzip (${kb(gz.length)} kB)`);
 }
 const iife = gzipSync(readFileSync(resolve(dir, "../packages/svenjs/dist/svenjs.iife.js")));
-if (iife.length > 5632) {
-  console.warn("IIFE gzip exceeds 5.5 kB target");
+if (iife.length > 6144) {
+  console.warn("IIFE gzip exceeds 6 kB budget");
   failed = true;
 }
 if (failed) process.exitCode = 1;


### PR DESCRIPTION
## Summary
SvenJS runtime contracts for 3.3: vnode `adopt()` isolation, `onMount` after DOM commit, robust unmount, form SSR/hydration, `onDoubleClick` → `dblclick`, store notification waves, published dev builds, and the 6 kB IIFE budget.

## Test plan
- [x] `pnpm --filter svenjs test` (92 tests)
- [x] `pnpm --filter svenjs check:pack`

Depends on #10. Stack: 2/4.