### PR TITLE
feat: make playground share/export trustworthy and document 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ This document broadly follows [Keep a Changelog](https://keepachangelog.com/). D
 
 ## [Unreleased]
 
+Correctness work toward 3.3.0. Package version is still 3.2.1 until the release PR.
+
+### Fixed
+
+- Cached `html` templates and reused `h()` trees no longer share `_dom` / `_instance`. Sibling and root mounts of the same static template update, hide, hydrate, and unmount independently.
+- `onMount` runs after the current DOM insertion. Nested fields can focus when the root container is connected.
+- `onDestroy`, ref teardown, and `observe` unsubscribes finish even if one of them throws. `unmountRoot` is idempotent.
+- `textarea value` is SSR text content; `select value` marks the matching option `selected`. Hydration writes form properties, not just attributes.
+- `onDoubleClick` listens for native `dblclick`. Event props are recognized case-insensitively and never become inline HTML handlers.
+- Typed arrays no longer throw while freezing development state. `Map` / `Set` / `Date` / typed arrays clone but are not mutation-proof.
+- Playground share / copy / download read the live editor text. Preview uses the development IIFE; export inlines production.
+
+### Changed
+
+- Changing a `key` remounts that node outside lists as well. Keyed list moves are unchanged.
+- Store listeners see queued nested `set` values in order. A throwing listener does not skip the rest. `get()` updates immediately on nested `set`.
+- `dangerouslySetInnerHTML` wins when both it and children are set.
+
+### Added
+
+- Published development builds: `svenjs.dev.js`, `svenjs.iife.dev.js`, and a `development` export condition. Production imports stay small.
+- JSX `onClick` / `onDoubleClick` / `onInput` / `onKeyDown` (and similar) take the matching DOM event type. Extra component methods remain allowed; instance fields still live on `this`.
+
+### Size
+
+- Production IIFE gzip budget is **6,144 bytes** (was 5,632). The extra bytes pay for vnode `adopt()`, mount commit, robust unmount, form SSR, and store notification waves. Dev files are reported but not gated.
+- `pnpm verify`, PR CI, and a packed-tarball consumer check.
+
 ## [3.2.1] – 2026-09-03
 
 Throughput work in the 3.2 runtime. Public API and observable semantics are unchanged aside from the mixed-key correction noted below.

--- a/apps/www/docs/api.md
+++ b/apps/www/docs/api.md
@@ -1,0 +1,27 @@
+---
+title: API
+nav: API
+description: Exported SvenJS functions and the edges they support.
+order: 20
+---
+
+| Export | Role |
+| --- | --- |
+| `create(spec)` | Component spec. `render()` is required. Extra methods stay on the instance. |
+| `render(app, el)` | Mount or patch. |
+| `hydrate(app, el)` | Attach to server HTML. |
+| `renderToString(app)` | SSR. Runs `onBeforeMount`, never `onMount`. |
+| `unmountRoot(el)` | Destroy the app in `el`. Safe to call twice. |
+| `flushSync(fn?)` | Run `fn` and flush `setState` now. |
+| `html` / `h` / `jsx` | Same vnode model. |
+| `createStore` | Synchronous pub/sub. `observe` on a component unsubscribes on destroy. |
+| `version` | Installed package version string. |
+| `Fragment` | JSX fragment. |
+
+**State:** `setState` replaces the object. Updaters and microtask batching are supported. Development clones plain objects/arrays and freezes them.
+
+**Events:** DOM names. `onDoubleClick` → `dblclick`. Custom `onFooBar` → `"foobar"`. No synthetic system.
+
+**Forms:** controlled `input` / `textarea` / `select` (single). Not `select multiple`.
+
+**SSR stores:** create a store per app/request. Do not share mutable user data across `renderToString` calls.

--- a/apps/www/docs/install.md
+++ b/apps/www/docs/install.md
@@ -24,4 +24,4 @@ In `tsconfig.json` (or Vite's esbuild JSX settings):
 
 There is no separate `svenjsx` package. `svenjs/jsx-runtime` ships with the runtime.
 
-A CDN / script-tag build is emitted as `svenjs.iife.js` for the original “drop it in a page” goal.
+A CDN / script-tag build is emitted as `svenjs.iife.js` for the original “drop it in a page” goal. Pin the version you install (`svenjs@3.2.1`). Development diagnostics are a separate file: `svenjs.iife.dev.js` or the `development` export condition on `"svenjs"`. Production imports stay on `svenjs.js`.

--- a/apps/www/docs/jsx.md
+++ b/apps/www/docs/jsx.md
@@ -5,13 +5,14 @@ description: Configure and use the SvenJS automatic JSX runtime, fragments, attr
 order: 13
 ---
 
-JSX compiles to `h()` via the automatic runtime (`jsx` / `jsxs` / `Fragment`).
+JSX compiles through the automatic runtime (`jsx` / `jsxs` / `jsxDEV` / `Fragment`). Those functions build vnodes directly; they do not call `h()`. `h()` remains the public hyperscript helper.
 
 Supported:
 
 - `class` and `className`
 - `htmlFor` / `for`
-- `onClick`, `onDoubleClick`, `onInput`, `onKeyDown`, …
+- DOM events: `onClick`, `onDoubleClick` (native `dblclick`), `onInput`, `onKeyDown`, …
+- Any `on*` prop is treated as an event. `onFooBar` listens for `"foobar"`. String values are never written as inline HTML handlers.
 - boolean attributes (`disabled`, `checked`)
 - `style` as a string or object
 - `ref` as a callback, called with the element on mount and `null` on unmount

--- a/apps/www/docs/lifecycle.md
+++ b/apps/www/docs/lifecycle.md
@@ -10,12 +10,18 @@ Preferred names:
 | Hook | When |
 | --- | --- |
 | `onBeforeMount` | After the instance exists, before the first `render()` |
-| `onMount` | After the first DOM commit |
+| `onMount` | After the first DOM commit (the whole tree is inserted; refs have run) |
 | `onUpdate` | After every later patch |
 | `onDestroy` | Before the instance is removed |
 
 2.x aliases still work: `_beforeMount`, `_didMount`, `_didUpdate`. There was no unmount hook before; use `onDestroy`.
 
-`onMount` may call `setState`. That schedules one extra patch after mount — it does not re-run `onMount`.
+`onMount` may call `setState`. That schedules one extra patch after mount — it does not re-run `onMount`. Nested children run `onMount` before their parent. Refs run before `onMount`, so a ref callback can stash an element that `onMount` then focuses.
 
-Clear timers and subscriptions in `onDestroy`. The composition demo does this for its interval.
+`isConnected` is true in `onMount` only when the **root container** is in the document. Detached roots still mount; hooks still run.
+
+`onBeforeMount` also runs during `renderToString`. Put browser-only work in `onMount`. SSR never runs refs or `onMount`.
+
+`onDestroy`, ref teardown, and `observe` unsubscribe functions always run to completion even if one of them throws. The first error is rethrown after the rest of the cleanup.
+
+Clear timers and subscriptions in `onDestroy`. The composition demo does this for its interval. `unmountRoot(container)` is safe to call more than once.

--- a/apps/www/docs/lists.md
+++ b/apps/www/docs/lists.md
@@ -24,3 +24,5 @@ Keys are the identity of a row. Same key and type keeps the DOM node and any chi
 A new keyed node does not reuse an unkeyed sibling of the same type. Mix keys on a dynamic list only if you mean it — development warns when some children have keys and others do not.
 
 Mixed or duplicate keys on a dynamic list warn in development.
+
+Changing a `key` remounts that node even outside a list (a component root or a single child). List reorder with stable keys still moves DOM nodes.

--- a/apps/www/docs/one-file.md
+++ b/apps/www/docs/one-file.md
@@ -12,7 +12,7 @@ You do not need npm. Save this as `hello.html`, open it in a browser, click the 
 <html lang="en">
 <body>
   <div id="app"></div>
-  <script src="https://unpkg.com/svenjs@3"></script>
+  <script src="https://unpkg.com/svenjs@3.2.1"></script>
   <script>
     const { create, render, html } = Svenjs;
 

--- a/apps/www/docs/playground.md
+++ b/apps/www/docs/playground.md
@@ -7,7 +7,9 @@ order: 5
 
 The [playground](/play/) runs your script against a local IIFE build in a sandboxed iframe.
 
-Mission Control is the default example. Start its synthetic stream, sort or filter 100 keyed units while the SVG telemetry moves, then export the exact demo.
+The playground opens the small **Click** example. Mission Control is in the example list when you want the larger demo. The editor edits **application source** inside an HTML wrapper — it is not a full HTML/CSS IDE.
+
+Preview uses the development runtime (key warnings and freeze checks). **Copy HTML** / **Download .html** embed the production runtime, current editor text, shared preview CSS, and the SvenJS credit chip. Open that file from disk: no npm, build step, network, or API key. A CDN starter still needs the network; the exported file does not.
 
 **Copy HTML** and **Download .html** embed the current SvenJS runtime, application source, and styles directly in one file. Open that file from disk: no npm, build step, network, or API key.
 

--- a/apps/www/docs/rendering.md
+++ b/apps/www/docs/rendering.md
@@ -31,6 +31,17 @@ Updates:
 
 DOM writes follow the tree, not the other way around. Unchanged style keys are not rewritten. A controlled `value` that already matches the input is left alone so the caret stays put. SVG attributes such as `points` still go through `setAttribute` — the animated `SVGPointList` property is not a string.
 
+Forms mean the same thing on the server and after hydration:
+
+- `textarea value` is serialized as **text content**, not a `value` attribute
+- `select value` marks the matching `option` as `selected`
+- hydration writes live properties, not just HTML attributes
+- user input typed before hydration is overwritten by a controlled value
+- `select multiple` is unsupported
+- if both `dangerouslySetInnerHTML` and children are set, innerHTML wins (development warns)
+
+Each `html` evaluation that is mounted gets its own DOM and instance, even when HTM reuses a static template.
+
 The 2.x renderer assigned `node.innerHTML = ""` on every update. That is gone on purpose.
 
 `flushSync(fn)` runs `fn` and flushes immediately. The site router uses it so view transitions see the new DOM.

--- a/apps/www/docs/state.md
+++ b/apps/www/docs/state.md
@@ -14,9 +14,11 @@ this.setState((s) => ({ ...s, clicks: s.clicks + 1 }));
 
 Several `setState` calls in one event are batched into a single microtask patch.
 
-In development the new state is `structuredClone`d and deep-frozen. Mutating `this.state.clicks++` throws. Production assigns the next value as-is — treat it as immutable.
+In development the new state is `structuredClone`d and plain objects/arrays are deep-frozen. Mutating `this.state.clicks++` throws. Production assigns the next value as-is — treat it as immutable.
 
-State must be structured-cloneable in development. Functions, DOM nodes, and similar runtime objects belong on the component instance (`this.timer`, `this.element`), not inside `this.state`; SvenJS throws a clear error instead of silently dropping them.
+`Map`, `Set`, `Date`, and typed arrays are allowed and cloned, but they are **not** mutation-proof after freeze. Functions, DOM nodes, and cyclic structures throw `TypeError: SvenJS: state must be structured-cloneable` and leave the previous state in place.
+
+Development diagnostics live in the published `svenjs.dev.js` / `svenjs.iife.dev.js` builds. `NODE_ENV=development` cannot restore code that was already stripped from the production file. Bundlers should honor the package `development` export condition; a script tag must load the `.dev.` file explicitly.
 
 `initialState` may be a value or a factory that receives props. A factory is useful when each mount needs state derived from its own props, and keeps server rendering and hydration deterministic.
 

--- a/apps/www/docs/store.md
+++ b/apps/www/docs/store.md
@@ -36,4 +36,8 @@ const List = create({
 });
 ```
 
+Store `set` notifies subscribers **synchronously**. Component `setState` still batches into a microtask. If a listener throws, later listeners still receive the update and the first error is rethrown afterwards.
+
+Nested `set` during a notification applies immediately for `get()`, then notifies every listener for each state in order. Nobody receives an older snapshot after a newer one.
+
 `listenTo` is an alias for `subscribe`. `emit(data)` is an alias for `set(data)`. Use `subscribe` yourself when the store update should derive local state, not just re-render.

--- a/apps/www/e2e/mission-control.spec.ts
+++ b/apps/www/e2e/mission-control.spec.ts
@@ -147,7 +147,6 @@ test("round-trips an edited built-in example through the share hash", async ({ p
   await page.keyboard.press("Control+End");
   await page.keyboard.insertText("\n// shared edit marker");
   await expect(editor).toContainText("shared edit marker");
-  await page.waitForTimeout(250);
 
   await page.getByRole("button", { name: "Copy share link" }).click();
   await expect(page).toHaveURL(/#example=click&code=/);

--- a/apps/www/e2e/smoke.spec.ts
+++ b/apps/www/e2e/smoke.spec.ts
@@ -89,8 +89,13 @@ test("home ships SoftwareApplication JSON-LD", async ({ request }) => {
   expect(html).toContain('"@type":"WebSite"');
 });
 
-test("playground runtime is a production IIFE", async ({ request }) => {
+test("playground preview is a development IIFE", async ({ request }) => {
   const js = await (await request.get("/playground-svenjs.js")).text();
+  expect(js).toContain("duplicate key");
+});
+
+test("playground export runtime is a production IIFE", async ({ request }) => {
+  const js = await (await request.get("/playground-svenjs.prod.js")).text();
   expect(js).not.toContain("duplicate key");
   expect(js.length).toBeLessThan(20_000);
 });

--- a/apps/www/public/preview.css
+++ b/apps/www/public/preview.css
@@ -100,3 +100,40 @@ input[type="text"] {
   border-radius: 12px;
   padding: 1rem 1.1rem;
 }
+
+.svenjs-credit {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--ink, #312725);
+  background: var(--field, #fffdf8);
+  border: 1px solid var(--rule, #d9d0c0);
+  padding: 6px 14px 6px 6px;
+  margin-top: 1.5rem;
+}
+.svenjs-credit:hover {
+  border-color: var(--accent, #e07a3d);
+}
+.svenjs-mark {
+  display: block;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+}
+.svenjs-credit-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  line-height: 1.15;
+}
+.svenjs-credit-kicker {
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted, #6a5e50);
+}
+.svenjs-credit-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+}

--- a/apps/www/src/lib/one-file.ts
+++ b/apps/www/src/lib/one-file.ts
@@ -1,4 +1,7 @@
-export const CDN = "https://unpkg.com/svenjs@3";
+import { version } from "svenjs";
+import previewCss from "../../public/preview.css?raw";
+
+export const CDN = "https://unpkg.com/svenjs@3.2.1";
 
 export const HELLO_JS = `const { create, render, html } = Svenjs;
 
@@ -145,16 +148,21 @@ const App = create({
 render(App, document.getElementById("app"));
 `;
 
-const PREVIEW_CSS = `body{font:16px/1.5 system-ui,sans-serif;margin:1.25rem;background:#141210;color:#f2ebe3}
-button{font:inherit;cursor:pointer;background:#e07a3d;color:#fff;border:0;border-radius:8px;padding:.55rem .95rem}
-input[type=text]{font:inherit;background:#1c1915;border:1px solid #3a342c;border-radius:8px;padding:.5rem .7rem;color:inherit}
-.demo-card,.todo-app{max-width:32rem}
-h1{font-size:1.6rem;margin:0 0 .8rem}
-.todo-list{list-style:none;margin:1rem 0;padding:0}
-.todo-list li{display:flex;gap:.6rem;align-items:center;padding:.5rem 0;border-bottom:1px solid #3a342c}
-.todo-list li.done label{opacity:.6;text-decoration:line-through}
-.destroy{margin-left:auto;background:transparent;color:#a3988c}
-.compose-grid{display:grid;gap:.75rem}`;
+const STAMP = `<a class="svenjs-credit" href="https://svenjs.xyz/" rel="noopener noreferrer">
+  <svg class="svenjs-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 326 326" width="36" height="36" aria-hidden="true">
+    <rect width="326" height="326" rx="72" fill="#312725"/>
+    <g fill="#e07a3d" transform="translate(0 4)">
+      <polygon points="127,73 258,73 204,130 78,129"/>
+      <polygon points="78,129 121,129 172,184 131,184"/>
+      <polygon points="154,139 198,139 249,195 205,195"/>
+      <polygon points="116,193 249,195 199,250 66,250"/>
+    </g>
+  </svg>
+  <span class="svenjs-credit-copy">
+    <span class="svenjs-credit-kicker">UI built with</span>
+    <span class="svenjs-credit-name">SvenJS ${version}</span>
+  </span>
+</a>`;
 
 export function wrapHtmlFile(script: string, runtimeSrc: string, inlineRuntime?: string, title = "SvenJS") {
   const safe = script.replace(/<\/script/gi, "<\\/script");
@@ -167,7 +175,7 @@ export function wrapHtmlFile(script: string, runtimeSrc: string, inlineRuntime?:
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${title}</title>
-  <style>${PREVIEW_CSS}</style>
+  <style>${previewCss}</style>
 </head>
 <body>
   <div id="app"></div>
@@ -175,6 +183,7 @@ export function wrapHtmlFile(script: string, runtimeSrc: string, inlineRuntime?:
   <script>
 ${safe}
   </script>
+  ${STAMP}
 </body>
 </html>
 `;

--- a/apps/www/src/pages/play.tsx
+++ b/apps/www/src/pages/play.tsx
@@ -66,6 +66,14 @@ function previewDoc(source: string, error: string) {
 </head>
 <body>
   <div id="app"></div>
+  <script>
+    window.addEventListener("error", function (event) {
+      parent.postMessage({ type: "sven-preview-error", message: String(event.message || event.error || "Preview error") }, "*");
+    });
+    window.addEventListener("unhandledrejection", function (event) {
+      parent.postMessage({ type: "sven-preview-error", message: String(event.reason) }, "*");
+    });
+  </script>
   <script src="${runtime}"></script>
   <script>${safe}</script>
 </body>
@@ -94,11 +102,11 @@ function readHash() {
 export const PlayPage = create({
   initialState() {
     if (typeof location === "undefined") {
-      return { source: MISSION_JS, example: "mission", error: "", copied: "" };
+      return { source: HELLO_JS, example: "click", error: "", copied: "" };
     }
     const shared = readHash();
-    const requested = new URLSearchParams(location.search).get("example") ?? "mission";
-    const example = EXAMPLES[requested] ? requested : "mission";
+    const requested = new URLSearchParams(location.search).get("example") ?? "click";
+    const example = EXAMPLES[requested] ? requested : "click";
     return {
       source: shared?.source || EXAMPLES[example],
       example: shared?.example ?? example,
@@ -151,41 +159,88 @@ export const PlayPage = create({
     });
     this.applySource(source, name);
   },
+  sourceSnapshot() {
+    return this.view ? this.view.state.doc.toString() : this.state.source;
+  },
+  bindFrame(el: HTMLIFrameElement | null) {
+    this._iframe = el;
+  },
+  onPreviewMessage(event: MessageEvent) {
+    if (event.source !== this._iframe?.contentWindow) return;
+    const data = event.data;
+    if (!data || data.type !== "sven-preview-error") return;
+    this.setState({ ...this.state, error: String(data.message ?? "Preview error"), copied: "" });
+  },
+  onMount() {
+    this._onMessage = (event: MessageEvent) => this.onPreviewMessage(event);
+    window.addEventListener("message", this._onMessage);
+  },
   share() {
-    const params = new URLSearchParams({ example: this.state.example });
-    if (EXAMPLES[this.state.example] !== this.state.source) {
-      params.set("code", LZString.compressToEncodedURIComponent(this.state.source));
+    const source = this.sourceSnapshot();
+    const example = this.state.example;
+    const params = new URLSearchParams({ example });
+    if (EXAMPLES[example] !== source) {
+      params.set("code", LZString.compressToEncodedURIComponent(source));
     }
     const hash = params.toString();
     const url = `${location.origin}/play/#${hash}`;
     history.replaceState({}, "", `/play/#${hash}`);
-    navigator.clipboard?.writeText(url);
-    this.setState({ ...this.state, copied: "link" });
+    const write = navigator.clipboard?.writeText(url);
+    if (!write) {
+      this.setState({ ...this.state, source, example, copied: "", error: "Clipboard is not available." });
+      return;
+    }
+    write.then(
+      () => this.setState({ ...this.state, source, example, copied: "link", error: "" }),
+      () => this.setState({ ...this.state, source, example, copied: "", error: "Could not copy the share link." }),
+    );
   },
   async fileHtml() {
-    const runtime = await fetch(`${location.origin}/playground-svenjs.js`).then((r) => r.text());
-    const script = toIframeScript(this.state.source);
+    const source = this.sourceSnapshot();
+    const res = await fetch(`${location.origin}/playground-svenjs.prod.js`);
+    if (!res.ok) throw new Error(`Could not load the SvenJS runtime (${res.status}).`);
+    const runtime = await res.text();
+    const script = toIframeScript(source);
     const title = this.state.example === "mission" ? "SvenJS Mission Control" : "SvenJS";
     return wrapHtmlFile(script, CDN, runtime, title);
   },
   copyHtml() {
-    this.fileHtml().then((html: string) => {
-      navigator.clipboard?.writeText(html);
-      this.setState({ ...this.state, copied: "html" });
-    });
+    this.fileHtml().then(
+      (html: string) =>
+        navigator.clipboard.writeText(html).then(
+          () => this.setState({ ...this.state, copied: "html", error: "" }),
+          () => this.setState({ ...this.state, copied: "", error: "Could not copy HTML." }),
+        ),
+      (err: unknown) =>
+        this.setState({
+          ...this.state,
+          copied: "",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+    );
   },
   downloadHtml() {
-    this.fileHtml().then((html: string) => {
-      const blob = new Blob([html], { type: "text/html" });
-      const a = document.createElement("a");
-      a.href = URL.createObjectURL(blob);
-      a.download = "svenjs-app.html";
-      a.click();
-      URL.revokeObjectURL(a.href);
-    });
+    this.fileHtml().then(
+      (html: string) => {
+        const blob = new Blob([html], { type: "text/html" });
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = "svenjs-app.html";
+        a.click();
+        URL.revokeObjectURL(a.href);
+        this.setState({ ...this.state, copied: "", error: "" });
+      },
+      (err: unknown) =>
+        this.setState({
+          ...this.state,
+          copied: "",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+    );
   },
   onDestroy() {
     clearTimeout(this._timer);
+    if (this._onMessage) window.removeEventListener("message", this._onMessage);
     this.view?.destroy();
   },
   render() {
@@ -229,6 +284,7 @@ export const PlayPage = create({
             className="play-preview"
             title="Playground preview"
             sandbox="allow-scripts"
+            ref={this.bindFrame}
             srcdoc={previewDoc(this.state.source, this.state.error)}
           />
         </div>

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -70,8 +70,10 @@ function playgroundRuntime(): Plugin {
     configureServer(server) {
       server.middlewares.use(async (req, res, next) => {
         const url = req.url?.split("?")[0];
-        if (url !== "/playground-svenjs.js") return next();
-        const code = await bundle(false);
+        const dev = url === "/playground-svenjs.js";
+        const prod = url === "/playground-svenjs.prod.js";
+        if (!dev && !prod) return next();
+        const code = await bundle(!dev);
         res.setHeader("Content-Type", "application/javascript; charset=utf-8");
         res.setHeader("Cache-Control", "no-cache");
         res.end(code);
@@ -81,6 +83,11 @@ function playgroundRuntime(): Plugin {
       this.emitFile({
         type: "asset",
         fileName: "playground-svenjs.js",
+        source: await bundle(false),
+      });
+      this.emitFile({
+        type: "asset",
+        fileName: "playground-svenjs.prod.js",
         source: await bundle(true),
       });
     },

--- a/examples/hello.html
+++ b/examples/hello.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="https://unpkg.com/svenjs@3"></script>
+  <script src="https://unpkg.com/svenjs@3.2.1"></script>
   <script>
     const { create, render, html } = Svenjs;
 


### PR DESCRIPTION
## Summary
Playground reads live editor text for share/copy/download, previews with the development IIFE, exports production runtime + shared CSS + credit chip, and documents the 3.3 contracts.

## Test plan
- [x] `pnpm test:e2e` (16 Chromium tests)

Depends on #11. Stack: 3/4.