### PR TITLE
chore: release SvenJS 3.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,19 @@
 # SvenJS
 
-SvenJS **3.2.1** is the current release on npm: https://www.npmjs.com/package/svenjs
+SvenJS **3.3.0** is the current release on npm: https://www.npmjs.com/package/svenjs
 
 This file is for coding agents that implement a UI **with** SvenJS, and for agents working in this repository. Human docs: https://svenjs.vercel.app/docs/
 
 ## Package
 
-Pin **3.2.1**. Import from `"svenjs"` only. Do not use React, Vue, hooks, `useState`, or the old `svenjsx-loader`.
+Pin **3.3.0**. Import from `"svenjs"` only. Do not use React, Vue, hooks, `useState`, or the old `svenjsx-loader`.
 
 | Path | Install |
 | --- | --- |
-| Bundler / Vite / npm | `npm install svenjs@3.2.1` |
-| One HTML file, no build | `<script src="https://unpkg.com/svenjs@3.2.1"></script>` then `const { create, render, html, version } = Svenjs;` |
+| Bundler / Vite / npm | `npm install svenjs@3.3.0` |
+| One HTML file, no build | `<script src="https://unpkg.com/svenjs@3.3.0"></script>` then `const { create, render, html, version } = Svenjs;` |
 
-`version` is the string `"3.2.1"`. Use it in the stamp so the label matches the installed package.
+`version` is the string `"3.3.0"`. Use it in the stamp so the label matches the installed package.
 
 ## Implement a UI
 
@@ -54,7 +54,7 @@ render(<App />, document.getElementById("app"));
 ### One HTML file
 
 ```html
-<script src="https://unpkg.com/svenjs@3.2.1"></script>
+<script src="https://unpkg.com/svenjs@3.3.0"></script>
 <div id="app"></div>
 <script>
   const { create, render, html, version } = Svenjs;
@@ -107,7 +107,7 @@ import svenjsMark from "./svenjs-mark.svg";
 </a>
 ```
 
-Hardcoding `SvenJS 3.2.1` is also correct if it matches the installed package.
+Hardcoding `SvenJS 3.3.0` is also correct if it matches the installed package.
 
 ### CSS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This document broadly follows [Keep a Changelog](https://keepachangelog.com/). D
 
 ## [Unreleased]
 
-Correctness work toward 3.3.0. Package version is still 3.2.1 until the release PR.
+## [3.3.0] – 2026-09-05
 
 ### Fixed
 

--- a/apps/www/docs/install.md
+++ b/apps/www/docs/install.md
@@ -24,4 +24,4 @@ In `tsconfig.json` (or Vite's esbuild JSX settings):
 
 There is no separate `svenjsx` package. `svenjs/jsx-runtime` ships with the runtime.
 
-A CDN / script-tag build is emitted as `svenjs.iife.js` for the original “drop it in a page” goal. Pin the version you install (`svenjs@3.2.1`). Development diagnostics are a separate file: `svenjs.iife.dev.js` or the `development` export condition on `"svenjs"`. Production imports stay on `svenjs.js`.
+A CDN / script-tag build is emitted as `svenjs.iife.js` for the original “drop it in a page” goal. Pin the version you install (`svenjs@3.3.0`). Development diagnostics are a separate file: `svenjs.iife.dev.js` or the `development` export condition on `"svenjs"`. Production imports stay on `svenjs.js`.

--- a/apps/www/docs/one-file.md
+++ b/apps/www/docs/one-file.md
@@ -12,7 +12,7 @@ You do not need npm. Save this as `hello.html`, open it in a browser, click the 
 <html lang="en">
 <body>
   <div id="app"></div>
-  <script src="https://unpkg.com/svenjs@3.2.1"></script>
+  <script src="https://unpkg.com/svenjs@3.3.0"></script>
   <script>
     const { create, render, html } = Svenjs;
 

--- a/apps/www/src/lib/one-file.ts
+++ b/apps/www/src/lib/one-file.ts
@@ -1,7 +1,7 @@
 import { version } from "svenjs";
 import previewCss from "../../public/preview.css?raw";
 
-export const CDN = "https://unpkg.com/svenjs@3.2.1";
+export const CDN = "https://unpkg.com/svenjs@3.3.0";
 
 export const HELLO_JS = `const { create, render, html } = Svenjs;
 

--- a/examples/hello.html
+++ b/examples/hello.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="https://unpkg.com/svenjs@3.2.1"></script>
+  <script src="https://unpkg.com/svenjs@3.3.0"></script>
   <script>
     const { create, render, html } = Svenjs;
 

--- a/packages/svenjs/package.json
+++ b/packages/svenjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svenjs",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A tiny UI runtime. One HTML file, a button, state. No npm required.",
   "keywords": [
     "ui",

--- a/packages/svenjs/src/index.ts
+++ b/packages/svenjs/src/index.ts
@@ -6,7 +6,7 @@ import { createStore } from "./store";
 import { FRAGMENT } from "./types";
 import { jsx, jsxDEV, jsxs } from "./jsx-runtime";
 
-export const version = "3.2.1";
+export const version = "3.3.0";
 
 export { create, createStore, flushSync, FRAGMENT as Fragment, h, html, hydrate, jsx, jsxDEV, jsxs, render, renderToString, unmountRoot };
 export type { Component, ComponentSpec, JSX, Key, Observable, Props, SvenComponent, VNode } from "./types";


### PR DESCRIPTION
## Summary
Sets package version, exported `version`, AGENTS.md, CDN pins, and changelog to **3.3.0**.

## Test plan
- [x] `version` export matches `packages/svenjs/package.json`

Depends on #12. Stack: 4/4.