### PR TITLE
chore: publish to npm with GitHub OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,22 +6,24 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v4
         with:
           version: 10.34.5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          registry-url: https://registry.npmjs.org/
+      - run: npm install -g npm@11
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
       - run: pnpm --filter svenjs publish --access public --no-git-checks --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
## Summary
Switch the release publish job to npm trusted publishing (OIDC). The trusted-publisher **workflow filename** stays \`npm-publish.yml\`.

- \`id-token: write\` for OIDC
- Node 22 and npm 11 (required by trusted publishing)
- No \`NODE_AUTH_TOKEN\` / \`npm_token\` secret

On npmjs.com → svenjs → Trusted Publisher:

- Organization or user: \`robbestad\`
- Repository: \`svenjs\`
- Workflow filename: \`npm-publish.yml\`
- Environment: leave empty
- Allow \`npm publish\` (not only staged publish)

## Test plan
- [ ] Save the trusted publisher on npm
- [ ] Merge this PR
- [ ] Re-run https://github.com/robbestad/svenjs/actions/runs/33975449558