### PR TITLE
chore: run CI on Node 22.23.2 and drop Node 20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22.23.2
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
@@ -26,13 +26,13 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22.23.2
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter www exec playwright install --with-deps chromium

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,12 +15,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 22.23.2
           registry-url: https://registry.npmjs.org/
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.5
       - run: npm install -g npm@11


### PR DESCRIPTION
## Why

`verify` and `e2e` warn:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`.

That is the **action JS runtime**, not only `setup-node` `node-version`. CI was still on Node 20; publish was on unpinned Node 22.

## Change

- Pin `node-version: 22.23.2` in `ci.yml` (verify + e2e) and `npm-publish.yml`.
- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v7`
- `pnpm/action-setup@v4` → `@v6`
- Keep pnpm `10.34.5`, OIDC trusted publishing, and `engines.node: ">=20"` for local installs.

22.23.2 is current Node 22 LTS (`https://nodejs.org/dist/v22.23.2/` returns 200).